### PR TITLE
feat: add Fedora support to install scripts

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -3,9 +3,14 @@
 export PYENV_ROOT="$ANYENV_ROOT/envs/pyenv"
 export MINT_PATH="$HOME/.mint"
 export MINT_LINK_PATH="$MINT_PATH/bin"
-export CPPFLAGS="-I/opt/homebrew/opt/openjdk@11/include"
-export ANDROID_HOME="$HOME/Library/Android/sdk"
 export BUN_INSTALL="$HOME/.bun"
+
+if [ "$(uname)" = "Darwin" ]; then
+  export CPPFLAGS="-I/opt/homebrew/opt/openjdk@11/include"
+  export ANDROID_HOME="$HOME/Library/Android/sdk"
+elif [ "$(uname)" = "Linux" ]; then
+  export ANDROID_HOME="$HOME/Android/Sdk"
+fi
 
 path=(
     $HOME/.local/bin(N-/)

--- a/.zshrc
+++ b/.zshrc
@@ -1,24 +1,27 @@
-if [ `uname -m` = "arm64" ]; then
+if [ -d /opt/homebrew/opt/zplug ]; then
   export ZPLUG_HOME=/opt/homebrew/opt/zplug
-  source $ZPLUG_HOME/init.zsh
-else
+elif [ -d /usr/local/opt/zplug ]; then
   export ZPLUG_HOME=/usr/local/opt/zplug
+elif [ -d "$HOME/.zplug" ]; then
+  export ZPLUG_HOME="$HOME/.zplug"
+fi
+if [ -n "$ZPLUG_HOME" ] && [ -f "$ZPLUG_HOME/init.zsh" ]; then
   source $ZPLUG_HOME/init.zsh
+
+  # syntax
+  zplug "chrissicool/zsh-256color"
+  zplug "Tarrasch/zsh-colors"
+  # compinit 以降に読み込むようにロードの優先度を変更する
+  zplug "zsh-users/zsh-syntax-highlighting", defer:2
+  zplug "ascii-soup/zsh-url-highlighter"
+
+  # tools
+  zplug "marzocchi/zsh-notify"
+  zplug mafredri/zsh-async, from:github
+  zplug sindresorhus/pure, use:pure.zsh, from:github, as:theme
 fi
 
 chpwd() { ls -lr }
-
-# syntax
-zplug "chrissicool/zsh-256color"
-zplug "Tarrasch/zsh-colors"
-# compinit 以降に読み込むようにロードの優先度を変更する
-zplug "zsh-users/zsh-syntax-highlighting", defer:2
-zplug "ascii-soup/zsh-url-highlighter"
-
-# tools
-zplug "marzocchi/zsh-notify"
-zplug mafredri/zsh-async, from:github
-zplug sindresorhus/pure, use:pure.zsh, from:github, as:theme
 
 # Load custom functions from .zsh/functions directory
 if [ -d "$HOME/.zsh/functions" ]; then
@@ -108,15 +111,17 @@ if [ -f ~/.dircolors ]; then
 fi
 
 # 未インストール項目をインストールする
-if ! zplug check --verbose; then
+if [ -n "$ZPLUG_HOME" ] && command -v zplug > /dev/null 2>&1; then
+  if ! zplug check --verbose; then
     printf "Install? [y/N]: "
     if read -q; then
-        echo; zplug install
+      echo; zplug install
     fi
-fi
+  fi
 
-# コマンドをリンクして、PATH に追加し、プラグインは読み込む
-zplug load
+  # コマンドをリンクして、PATH に追加し、プラグインは読み込む
+  zplug load
+fi
 
 eval "$(mise activate zsh)"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 ## Installation
+
+### macOS / Fedora
 ```bash
 bash -c "$(curl -fsSL https://bit.ly/3X8YDzE)"
+```
+
+Fedora では `sudo` 権限が必要です（`dnf` でパッケージをインストールします）。
+インストール後、ログインシェルを zsh に変更してください。
+
+```bash
+chsh -s "$(command -v zsh)"
 ```

--- a/etc/init/install.sh
+++ b/etc/init/install.sh
@@ -11,6 +11,20 @@ is_macos() {
     test "$(uname)" == "Darwin"
 }
 
+is_linux() {
+    test "$(uname)" == "Linux"
+}
+
+is_fedora() {
+    if [ -f /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        test "${ID:-}" == "fedora"
+    else
+        return 1
+    fi
+}
+
 if [ -n "$CI" ] ; then
     DOTPATH=$RUNNER_WORKSPACE/dotfiles
 fi
@@ -19,8 +33,11 @@ if is_macos ; then
     echo "macOS detected. Calling macOS install scripts..."
     source ${DOTPATH}/etc/init/osx/install
     source ${DOTPATH}/etc/init/osx/change_defaults.sh
-else 
-    echo "Not macOS! Abort."
+elif is_linux && is_fedora ; then
+    echo "Fedora detected. Calling Fedora install scripts..."
+    source ${DOTPATH}/etc/init/linux/fedora/install
+else
+    echo "Unsupported OS. Skipping OS-specific package installation."
 fi
 
 # Deinのインストールスクリプトが対話型のため、CIでは無効にする

--- a/etc/init/linux/fedora/install
+++ b/etc/init/linux/fedora/install
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# エラーがあったらそこで即終了
+set -eo pipefail
+# Prevent commands misbehaving due to locale differences
+export LC_ALL=C
+
+DOTPATH=${DOTPATH:-$HOME/dotfiles}
+
+if [ -n "$CI" ]; then
+    DOTPATH=$RUNNER_WORKSPACE/dotfiles
+fi
+
+# Brewfile.test に対応する Fedora パッケージ
+PACKAGES=(
+    awscli
+    bat
+    colordiff
+    fd-find
+    ffmpeg
+    fzf
+    gh
+    git
+    git-delta
+    jq
+    libjxl
+    libwebp-tools
+    scrcpy
+    yt-dlp
+    zsh
+    java-11-openjdk-devel
+)
+
+echo "Installing packages via dnf..."
+sudo dnf install -y "${PACKAGES[@]}"
+
+# Fedora の fd-find は fdfind コマンド名で提供される
+if ! command -v fd > /dev/null 2>&1 && command -v fdfind > /dev/null 2>&1; then
+    mkdir -p "$HOME/.local/bin"
+    ln -sfn "$(command -v fdfind)" "$HOME/.local/bin/fd"
+fi
+
+# zplug
+if [ ! -d "$HOME/.zplug" ]; then
+    echo "Installing zplug..."
+    git clone https://github.com/zplug/zplug "$HOME/.zplug"
+fi
+
+# mise (.zshrc で使用)
+if ! command -v mise > /dev/null 2>&1; then
+    echo "Installing mise..."
+    curl -fsSL https://mise.run | sh
+fi
+
+mkdir -p "$HOME/.config/git"
+if [ ! -f "$HOME/.config/git/ignore" ]; then
+    touch "$HOME/.config/git/ignore"
+fi

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,20 @@ is_macos() {
     test "$(uname)" == "Darwin"
 }
 
+is_linux() {
+    test "$(uname)" == "Linux"
+}
+
+is_fedora() {
+    if [ -f /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        test "${ID:-}" == "fedora"
+    else
+        return 1
+    fi
+}
+
 is_arm() { 
     test "$UNAME" == "arm64"
 }
@@ -42,26 +56,37 @@ if [ -n "$CI" ] ; then
     DOTPATH=$RUNNER_WORKSPACE/dotfiles
 fi
 
-if ! is_macos ; then
-    echo "not macOS! Abort."
-    exit 1
-fi
+if is_macos ; then
+    # Rosetta2 でターミナルを動かしている時には強制終了させる
+    if ! is_arm ; then
+        echo "x86 Processor Detected"
+        if is_rosseta2 ; then
+            echo "This script can not exec in Rosetta2 terminal. Abort."
+            exit 1
+        fi
+    else
+        echo "ARM Processor Detected."
+    fi
 
-# Rosetta2 でターミナルを動かしている時には強制終了させる
-if ! is_arm ; then
-    echo "x86 Processor Detected"
-    if is_rosseta2 ; then
-        echo "This script can not exec in Rosetta2 terminal. Abort."
+    if !( xcode-select -p > /dev/null 2>&1 ); then
+        echo "Installing Xcode CLT..."
+        echo "Please re-run after Xcode CLT installation is complete."
+        xcode-select --install
+    fi
+elif is_linux ; then
+    if is_fedora ; then
+        echo "Fedora detected."
+        if ! command -v git > /dev/null 2>&1; then
+            echo "Installing git..."
+            sudo dnf install -y git
+        fi
+    else
+        echo "Unsupported Linux distribution. Abort."
         exit 1
     fi
 else
-    echo "ARM Processor Detected."
-fi
-
-if !( xcode-select -p > /dev/null 2>&1 ); then
-    echo "Installing Xcode CLT..."
-    echo "Please re-run after Xcode CLT installation is complete."
-    xcode-select --install
+    echo "Unsupported OS. Abort."
+    exit 1
 fi
 
 dotfiles_download


### PR DESCRIPTION
## Summary
- README のワンライナー (`install.sh`) を Fedora でも実行できるように OS 判定を追加
- `etc/init/linux/fedora/install` で `dnf` パッケージ・zplug・mise をセットアップ
- `.zshrc` / `.zshenv` を Linux 向けパス（`~/.zplug`, `~/Android/Sdk`）に対応

## Test plan
- [ ] Fedora で `bash install.sh` を実行し、`not macOS! Abort.` が出ないこと
- [ ] `dnf` によるパッケージインストールが完了すること
- [ ] `make install` / `make deploy` が正常終了すること
- [ ] `chsh -s "$(command -v zsh)"` 後に zsh が起動し、zplug / mise が読み込まれること
- [ ] macOS での既存インストールフローに影響がないこと


Made with [Cursor](https://cursor.com)