### PR TITLE
fix: install make before running Makefile on Fedora

### DIFF
--- a/etc/init/linux/fedora/install
+++ b/etc/init/linux/fedora/install
@@ -24,6 +24,7 @@ PACKAGES=(
     jq
     libjxl
     libwebp-tools
+    make
     scrcpy
     yt-dlp
     zsh

--- a/install.sh
+++ b/install.sh
@@ -76,9 +76,12 @@ if is_macos ; then
 elif is_linux ; then
     if is_fedora ; then
         echo "Fedora detected."
-        if ! command -v git > /dev/null 2>&1; then
-            echo "Installing git..."
-            sudo dnf install -y git
+        fedora_packages=()
+        command -v git > /dev/null 2>&1 || fedora_packages+=(git)
+        command -v make > /dev/null 2>&1 || fedora_packages+=(make)
+        if [ ${#fedora_packages[@]} -gt 0 ]; then
+            echo "Installing prerequisites: ${fedora_packages[*]}"
+            sudo dnf install -y "${fedora_packages[@]}"
         fi
     else
         echo "Unsupported Linux distribution. Abort."


### PR DESCRIPTION
## Summary
- Fedora の最小インストール環境では `make` が含まれないため、`make install` 前に失敗していた
- `install.sh` で clone 前に `git` / `make` を不足分だけ `dnf` インストールするよう修正
- `etc/init/linux/fedora/install` のパッケージ一覧にも `make` を追加

## Test plan
- [ ] Fedora で `bash -c "$(curl -fsSL https://bit.ly/3X8YDzE)"` を実行し、`make: command not found` が出ないこと
- [ ] `make install` / `make deploy` が正常終了すること
- [ ] macOS での既存インストールフローに影響がないこと


Made with [Cursor](https://cursor.com)