### PR TITLE
fix: install Fedora prerequisites after clone before make

### DIFF
--- a/etc/init/linux/fedora/prerequisites.sh
+++ b/etc/init/linux/fedora/prerequisites.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -eo pipefail
+export LC_ALL=C
+
+echo "Installing Fedora prerequisites..."
+sudo dnf install -y git make
+
+if ! command -v make > /dev/null 2>&1; then
+    echo "error: make is required but not available after dnf install"
+    exit 1
+fi

--- a/install.sh
+++ b/install.sh
@@ -76,12 +76,9 @@ if is_macos ; then
 elif is_linux ; then
     if is_fedora ; then
         echo "Fedora detected."
-        fedora_packages=()
-        command -v git > /dev/null 2>&1 || fedora_packages+=(git)
-        command -v make > /dev/null 2>&1 || fedora_packages+=(make)
-        if [ ${#fedora_packages[@]} -gt 0 ]; then
-            echo "Installing prerequisites: ${fedora_packages[*]}"
-            sudo dnf install -y "${fedora_packages[@]}"
+        if ! command -v git > /dev/null 2>&1; then
+            echo "Installing git..."
+            sudo dnf install -y git
         fi
     else
         echo "Unsupported Linux distribution. Abort."
@@ -93,6 +90,21 @@ else
 fi
 
 dotfiles_download
+
+if is_fedora && [ -d "${DOTPATH}" ]; then
+    prerequisites="${DOTPATH}/etc/init/linux/fedora/prerequisites.sh"
+    if [ -f "$prerequisites" ]; then
+        bash "$prerequisites"
+    else
+        echo "Installing prerequisites..."
+        sudo dnf install -y git make
+    fi
+fi
+
+if is_fedora && ! command -v make > /dev/null 2>&1; then
+    echo "error: make is required but not installed"
+    exit 1
+fi
 
 cd ${DOTPATH} && make install
 cd ${DOTPATH} && make deploy


### PR DESCRIPTION
## Summary
- `raw.githubusercontent.com/.../master/install.sh` が古い版を返すことがあり、PR #55 の修正が curl 経由で反映されないケースがあった
- clone 後に `etc/init/linux/fedora/prerequisites.sh` で `git` / `make` を必ず `dnf` インストールしてから `make install` を実行するよう変更
- 古い clone に `prerequisites.sh` がない場合は `install.sh` 側でフォールバック

## Test plan
- [ ] Fedora で `bash -c "$(curl -fsSL https://raw.githubusercontent.com/cottpan/dotfiles/master/install.sh)"` を実行し、`make: command not found` が出ないこと
- [ ] `~/dotfiles` が既に存在する状態で再実行しても prerequisites が走ること
- [ ] macOS での既存インストールフローに影響がないこと


Made with [Cursor](https://cursor.com)