### PR TITLE
fix: handle unavailable Fedora packages in dnf install

### DIFF
--- a/etc/init/linux/fedora/install
+++ b/etc/init/linux/fedora/install
@@ -47,18 +47,8 @@ else
     echo "warning: no OpenJDK devel package found in enabled repositories"
 fi
 
-# 標準リポジトリにないパッケージ（失敗しても続行）
-OPTIONAL_PACKAGES=(
-    scrcpy
-)
-
 echo "Installing packages via dnf..."
 sudo dnf install -y "${PACKAGES[@]}"
-
-if [ ${#OPTIONAL_PACKAGES[@]} -gt 0 ]; then
-    echo "Installing optional packages (skipping unavailable)..."
-    sudo dnf install -y --skip-unavailable "${OPTIONAL_PACKAGES[@]}" || true
-fi
 
 # Fedora の fd-find は fdfind コマンド名で提供される
 if ! command -v fd > /dev/null 2>&1 && command -v fdfind > /dev/null 2>&1; then

--- a/etc/init/linux/fedora/install
+++ b/etc/init/linux/fedora/install
@@ -10,7 +10,18 @@ if [ -n "$CI" ]; then
     DOTPATH=$RUNNER_WORKSPACE/dotfiles
 fi
 
-# Brewfile.test に対応する Fedora パッケージ
+fedora_java_devel_package() {
+    local pkg
+    for pkg in java-25-openjdk-devel java-21-openjdk-devel java-17-openjdk-devel java-latest-openjdk-devel; do
+        if dnf repoquery --available -q "$pkg" > /dev/null 2>&1; then
+            echo "$pkg"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Brewfile.test に対応する Fedora パッケージ（標準リポジトリ）
 PACKAGES=(
     awscli
     bat
@@ -25,14 +36,29 @@ PACKAGES=(
     libjxl
     libwebp-tools
     make
-    scrcpy
     yt-dlp
     zsh
-    java-11-openjdk-devel
+)
+
+JAVA_DEVEL=$(fedora_java_devel_package || true)
+if [ -n "$JAVA_DEVEL" ]; then
+    PACKAGES+=("$JAVA_DEVEL")
+else
+    echo "warning: no OpenJDK devel package found in enabled repositories"
+fi
+
+# 標準リポジトリにないパッケージ（失敗しても続行）
+OPTIONAL_PACKAGES=(
+    scrcpy
 )
 
 echo "Installing packages via dnf..."
 sudo dnf install -y "${PACKAGES[@]}"
+
+if [ ${#OPTIONAL_PACKAGES[@]} -gt 0 ]; then
+    echo "Installing optional packages (skipping unavailable)..."
+    sudo dnf install -y --skip-unavailable "${OPTIONAL_PACKAGES[@]}" || true
+fi
 
 # Fedora の fd-find は fdfind コマンド名で提供される
 if ! command -v fd > /dev/null 2>&1 && command -v fdfind > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Fedora 44 では `java-11-openjdk-devel` が標準リポジトリに存在しないため、利用可能な OpenJDK devel パッケージを自動検出するよう変更
- `scrcpy` は標準リポジトリにないため optional 扱いにし、`--skip-unavailable` でインストール失敗時も `make deploy` を継続

## Test plan
- [ ] Fedora 44 (aarch64) で `make deploy` が `scrcpy` / `java-11` 不足で失敗しないこと
- [ ] `java-25-openjdk-devel` などがインストールされること
- [ ] macOS での既存インストールフローに影響がないこと


Made with [Cursor](https://cursor.com)