### PR TITLE
fix: bootstrap dein.vim without overwriting dotfiles .vimrc

### DIFF
--- a/etc/init/install.sh
+++ b/etc/init/install.sh
@@ -40,12 +40,13 @@ else
     echo "Unsupported OS. Skipping OS-specific package installation."
 fi
 
-# Deinのインストールスクリプトが対話型のため、CIでは無効にする
-set +u
+# dotfiles の .vimrc で dein を管理するため、dein-installer は使わない
 if [ -z "$CI" ] ; then
-    mkdir -p $HOME/.vim/backup
-    sh -c "$(curl -fsSL https://raw.githubusercontent.com/Shougo/dein-installer.vim/master/installer.sh)"
-    rm $HOME/.vimrc
-    mv $HOME/.vimrc.pre-dein-vim $HOME/.vimrc
+    mkdir -p "$HOME/.vim/backup"
+    dein_path="$HOME/.cache/dein/repos/github.com/Shougo/dein.vim"
+    if [ ! -d "$dein_path" ]; then
+        echo "Installing dein.vim..."
+        mkdir -p "$(dirname "$dein_path")"
+        git clone --depth 1 https://github.com/Shougo/dein.vim.git "$dein_path"
+    fi
 fi
-set -u


### PR DESCRIPTION
## Summary
- `make install` で `.vimrc` が symlink 済みの状態では dein-installer が `.vimrc.pre-dein-vim` を作らず、`mv` で deploy が失敗していた
- dein-installer の代わりに `dein.vim` を `git clone` するだけに変更（プラグインは `.vimrc` の `dein#install()` に任せる）

## Test plan
- [ ] Fedora で `make deploy` が dein 手順で失敗しないこと
- [ ] `~/.vimrc` の dotfiles symlink が維持されること
- [ ] `~/.cache/dein/repos/github.com/Shougo/dein.vim` が作成されること
- [ ] macOS での deploy に影響がないこと


Made with [Cursor](https://cursor.com)