### PR TITLE
feat(tmux): show GitHub notifications and today's agenda in a popup

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -148,9 +148,24 @@ bind -r L resize-pane -R 5
 bind -r < swap-window -d -t -1
 bind -r > swap-window -d -t +1
 
-# 作業用ウィンドウ (エディタ + エージェント) を開く
-# 同名のウィンドウがあればそこへ移動する
+# 作業用ウィンドウ (エディタ + ターミナル + エージェント) を開く
 bind C run-shell '~/bin/tmux-workspace "#{pane_current_path}"'
+
+# ステータスバーのクリック
+# GitHub 通知と予定のセグメントは #[range=user|...] で囲ってあり、
+# クリックすると mouse_status_range にその名前が入る。
+# ウィンドウのタブをクリックした時 (range が window) は従来どおり切り替える
+bind -n MouseDown1Status {
+    if -F '#{==:#{mouse_status_range},gh}' {
+        display-popup -E -w 85% -h 60% '~/bin/tmux-status-popup github'
+    } {
+        if -F '#{==:#{mouse_status_range},cal}' {
+            display-popup -E -w 70% -h 50% '~/bin/tmux-status-popup calendar'
+        } {
+            select-window -t=
+        }
+    }
+}
 
 # 設定のリロード (既定の refresh-client は prefix + R に退避)
 bind r source-file ~/.tmux.conf \; display-message "sourced ~/.tmux.conf"

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -151,21 +151,12 @@ bind -r > swap-window -d -t +1
 # 作業用ウィンドウ (エディタ + ターミナル + エージェント) を開く
 bind C run-shell '~/bin/tmux-workspace "#{pane_current_path}"'
 
-# ステータスバーのクリック
-# GitHub 通知と予定のセグメントは #[range=user|...] で囲ってあり、
-# クリックすると mouse_status_range にその名前が入る。
-# ウィンドウのタブをクリックした時 (range が window) は従来どおり切り替える
-bind -n MouseDown1Status {
-    if -F '#{==:#{mouse_status_range},gh}' {
-        display-popup -E -w 85% -h 60% '~/bin/tmux-status-popup github'
-    } {
-        if -F '#{==:#{mouse_status_range},cal}' {
-            display-popup -E -w 70% -h 50% '~/bin/tmux-status-popup calendar'
-        } {
-            select-window -t=
-        }
-    }
-}
+# GitHub 通知と今日の予定をポップアップで開く
+# (ステータスバーのクリックでも開けるようにしたかったが、tmux の range=user は
+#  status-format に直接書いたものしか登録されず、status-right の #() 出力に入れても
+#  無視される。実測で確認したうえでキー操作にしている)
+bind g display-popup -E -w 85% -h 60% '~/bin/tmux-status-popup github'
+bind a display-popup -E -w 70% -h 50% '~/bin/tmux-status-popup calendar'
 
 # 設定のリロード (既定の refresh-client は prefix + R に退避)
 bind r source-file ~/.tmux.conf \; display-message "sourced ~/.tmux.conf"

--- a/bin/tmux-status-popup
+++ b/bin/tmux-status-popup
@@ -11,10 +11,15 @@ tmux の display-popup から呼ばれる想定で、コマンドが終わると
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 import unicodedata
+from pathlib import Path as pathlib_Path
 from datetime import datetime, timezone
+
+SELF = os.path.realpath(__file__)
 
 BROWSER_OPEN = "open" if sys.platform == "darwin" else "xdg-open"
 
@@ -69,21 +74,55 @@ def pause(message="\n閉じるには何かキーを押してください "):
         pass
 
 
-def choose(lines):
-    """fzf があれば選ばせて、選ばれた行を返す。無ければ表示するだけで None。"""
-    if not lines:
+def choose(items, prompt, header):
+    """fzf で選ばせる。右側に詳細を出す (fprwtree と同じ見せ方)。
+
+    items は (表示行, 詳細テキスト, URL) の並び。fzf が無ければ一覧を出すだけ。
+    戻り値は選ばれた項目の URL。
+    """
+    if not items:
         return None
     if not have("fzf"):
-        print("\n".join(lines))
+        print("\n".join(line for line, _, _ in items))
         pause()
         return None
-    out = run(
-        ["fzf", "--ansi", "--no-sort", "--reverse", "--prompt", "> ", "--header",
-         "Enter でブラウザを開く / Esc で閉じる"],
-        timeout=600,
-        stdin_text="\n".join(lines) + "\n",
-    )
-    return out.strip() if out else None
+
+    # 詳細はファイルに書いておき、プレビューは cat するだけにする (待ちを作らない)
+    workdir = tempfile.mkdtemp(prefix="tmux-status-popup-")
+    try:
+        lines = []
+        for index, (line, detail, url) in enumerate(items):
+            base = pathlib_Path(workdir) / str(index)
+            base.write_text(detail, encoding="utf-8")
+            # GitHub は本文をプレビュー時に取りに行く (件数分の API 呼び出しを避ける)
+            if url and url.startswith("https://api.github.com/"):
+                base.with_suffix(".url").write_text(url, encoding="utf-8")
+            lines.append(f"{index}\t{line}")
+
+        out = run(
+            [
+                "fzf",
+                "--delimiter", "\t",
+                "--with-nth", "2..",
+                "--prompt", prompt,
+                "--header", header,
+                "--preview", f"cat {workdir}/{{1}}; {SELF} --detail {workdir} {{1}}",
+                "--preview-window", "right:60%",
+                "--reverse",
+                "--border",
+                "--no-sort",
+            ],
+            timeout=600,
+            stdin_text="\n".join(lines) + "\n",
+        )
+        if not out:
+            return None
+        index = out.split("\t", 1)[0].strip()
+        if not index.isdigit() or int(index) >= len(items):
+            return None
+        return items[int(index)][2]
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
 
 
 def open_url(url):
@@ -128,28 +167,32 @@ def github():
         pause()
         return 0
 
-    lines = []
-    urls = {}
+    entries = []
     for item in items:
         repo = (item.get("repository") or {}).get("full_name", "")
         subject = item.get("subject") or {}
         title = subject.get("title", "")
+        kind = subject.get("type", "")
         reason = item.get("reason", "")
-        age = relative_time(item.get("updated_at", ""))
+        updated = item.get("updated_at", "")
+        age = relative_time(updated)
         line = f"{pad(repo, 28)} {pad(title, 52)} {pad(reason, 14)} {age}"
-        lines.append(line)
-        urls[line] = subject.get("url") or ""
+        detail = (
+            f"リポジトリ : {repo}\n"
+            f"種別       : {kind}\n"
+            f"理由       : {reason}\n"
+            f"更新       : {updated} ({age})\n"
+            f"\nタイトル\n{title}\n"
+        )
+        entries.append((line, detail, subject.get("url") or ""))
 
-    selected = choose(lines)
+    selected = choose(entries, "通知 > ", "Enter でブラウザを開く / Esc で閉じる")
     if not selected:
         return 0
 
-    api_url = urls.get(selected, "")
-    if not api_url:
-        return 0
     # subject.url は API のアドレスなので、ブラウザ用の URL を引き直す
-    detail = run(["gh", "api", api_url, "--jq", ".html_url"], timeout=30)
-    open_url((detail or "").strip())
+    html = run(["gh", "api", selected, "--jq", ".html_url"], timeout=30)
+    open_url((html or "").strip())
     return 0
 
 
@@ -181,8 +224,7 @@ def calendar():
         return 0
 
     now = datetime.now()
-    lines = []
-    urls = {}
+    entries = []
     seen = set()
     for block in out.split("@@"):
         if not block.strip():
@@ -223,21 +265,57 @@ def calendar():
 
         link = " [link]" if meeting else ""
         line = f"{marker} {pad(span, 12)} {pad(title, 46)}{link}"
-        lines.append(line)
-        urls[line] = meeting
 
-    if not lines:
+        state = {">": "進行中", "-": "終了"}.get(marker, "これから")
+        # notes には Google Meet の案内などが入るので、そのまま読めるよう整形する
+        notes = re.sub(r"<[^>]+>", "", body).replace(";;", "\n").strip()
+        notes = re.sub(r"\n{3,}", "\n\n", notes)
+        detail = (
+            f"予定   : {title}\n"
+            f"時間   : {span}\n"
+            f"状態   : {state}\n"
+            + (f"会議室 : {meeting}\n" if meeting else "")
+            + (f"\n--- メモ ---\n{notes[:1500]}\n" if notes else "")
+        )
+        entries.append((line, detail, meeting))
+
+    if not entries:
         print("今日の予定はありません")
         pause()
         return 0
 
-    selected = choose(lines)
-    if selected:
-        open_url(urls.get(selected, ""))
+    open_url(choose(entries, "予定 > ", "Enter で会議 URL を開く / Esc で閉じる"))
+    return 0
+
+
+def detail(workdir, index):
+    """プレビューから呼ばれ、GitHub の本文だけ遅れて表示する。
+
+    件数分の API 呼び出しを避けるため、見ている項目だけ取りに行って結果を残す。
+    """
+    base = pathlib_Path(workdir) / str(index)
+    cached = base.with_suffix(".body")
+    if cached.exists():
+        sys.stdout.write(cached.read_text(encoding="utf-8"))
+        return 0
+    url_file = base.with_suffix(".url")
+    if not url_file.exists():
+        return 0
+    api_url = url_file.read_text(encoding="utf-8").strip()
+    out = run(
+        ["gh", "api", api_url, "--jq",
+         '"状態   : " + (.state // "-") + "\n作成者 : " + (.user.login // "-") + "\n\n--- 本文 ---\n" + ((.body // "") | .[0:1500])'],
+        timeout=20,
+    )
+    text = f"\n{out}" if out else ""
+    cached.write_text(text, encoding="utf-8")
+    sys.stdout.write(text)
     return 0
 
 
 def main():
+    if len(sys.argv) >= 4 and sys.argv[1] == "--detail":
+        return detail(sys.argv[2], sys.argv[3])
     if len(sys.argv) < 2:
         print(__doc__)
         return 2

--- a/bin/tmux-status-popup
+++ b/bin/tmux-status-popup
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""ステータスバーのセグメントをクリックしたときに開くポップアップ。
+
+    tmux-status-popup github     未読の GitHub 通知を一覧する
+    tmux-status-popup calendar   今日の予定を一覧する
+
+fzf があれば選択して Enter でブラウザを開く。無ければ一覧を表示するだけ。
+tmux の display-popup から呼ばれる想定で、コマンドが終わるとポップアップも閉じる。
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import unicodedata
+from datetime import datetime, timezone
+
+BROWSER_OPEN = "open" if sys.platform == "darwin" else "xdg-open"
+
+
+def run(cmd, timeout=30, stdin_text=None):
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, check=False, input=stdin_text
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def have(command):
+    return any(
+        os.access(os.path.join(path, command), os.X_OK)
+        for path in os.environ.get("PATH", "").split(os.pathsep)
+        if path
+    )
+
+
+def display_width(text):
+    return sum(2 if unicodedata.east_asian_width(c) in ("W", "F") else 1 for c in text)
+
+
+def pad(text, columns):
+    """全角を 2 桁として数えて右側を埋める。"""
+    width = display_width(text)
+    if width > columns:
+        out = ""
+        acc = 0
+        for char in text:
+            step = 2 if unicodedata.east_asian_width(char) in ("W", "F") else 1
+            if acc + step > columns - 1:
+                break
+            out += char
+            acc += step
+        return out + "…" + " " * max(0, columns - acc - 1)
+    return text + " " * (columns - width)
+
+
+def pause(message="\n閉じるには何かキーを押してください "):
+    """display-popup はコマンドが終わると閉じるので、読む時間を作る。"""
+    sys.stdout.write(message)
+    sys.stdout.flush()
+    try:
+        subprocess.run(["sh", "-c", "stty raw -echo 2>/dev/null; dd bs=1 count=1 2>/dev/null; stty sane 2>/dev/null"], check=False)
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+
+def choose(lines):
+    """fzf があれば選ばせて、選ばれた行を返す。無ければ表示するだけで None。"""
+    if not lines:
+        return None
+    if not have("fzf"):
+        print("\n".join(lines))
+        pause()
+        return None
+    out = run(
+        ["fzf", "--ansi", "--no-sort", "--reverse", "--prompt", "> ", "--header",
+         "Enter でブラウザを開く / Esc で閉じる"],
+        timeout=600,
+        stdin_text="\n".join(lines) + "\n",
+    )
+    return out.strip() if out else None
+
+
+def open_url(url):
+    if url:
+        subprocess.run([BROWSER_OPEN, url], check=False)
+
+
+def relative_time(stamp):
+    try:
+        when = datetime.strptime(stamp, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return ""
+    delta = datetime.now(timezone.utc) - when
+    minutes = int(delta.total_seconds() // 60)
+    if minutes < 60:
+        return f"{max(minutes, 0)}分前"
+    if minutes < 60 * 24:
+        return f"{minutes // 60}時間前"
+    return f"{minutes // (60 * 24)}日前"
+
+
+# --------------------------------------------------------------------------
+# GitHub の通知
+# --------------------------------------------------------------------------
+
+
+def github():
+    out = run(["gh", "api", "--paginate", "notifications"], timeout=60)
+    if out is None:
+        print("gh で通知を取得できませんでした (gh auth status を確認してください)")
+        pause()
+        return 1
+
+    items = []
+    for chunk in re.findall(r"\[.*?\]\s*(?=\[|$)", out, re.S) or [out]:
+        try:
+            items.extend(json.loads(chunk))
+        except ValueError:
+            continue
+    if not items:
+        print("未読の通知はありません")
+        pause()
+        return 0
+
+    lines = []
+    urls = {}
+    for item in items:
+        repo = (item.get("repository") or {}).get("full_name", "")
+        subject = item.get("subject") or {}
+        title = subject.get("title", "")
+        reason = item.get("reason", "")
+        age = relative_time(item.get("updated_at", ""))
+        line = f"{pad(repo, 28)} {pad(title, 52)} {pad(reason, 14)} {age}"
+        lines.append(line)
+        urls[line] = subject.get("url") or ""
+
+    selected = choose(lines)
+    if not selected:
+        return 0
+
+    api_url = urls.get(selected, "")
+    if not api_url:
+        return 0
+    # subject.url は API のアドレスなので、ブラウザ用の URL を引き直す
+    detail = run(["gh", "api", api_url, "--jq", ".html_url"], timeout=30)
+    open_url((detail or "").strip())
+    return 0
+
+
+# --------------------------------------------------------------------------
+# 今日の予定
+# --------------------------------------------------------------------------
+
+
+def calendar():
+    if sys.platform != "darwin" or not have("icalBuddy"):
+        print("icalBuddy が無いため予定を取得できません")
+        pause()
+        return 1
+
+    # イベントごとに @@ で始まり、最後の ;; の後ろに日時が来る。
+    # notes は複数行にまたがるので、行単位ではなくブロック単位で切り出す
+    out = run(
+        [
+            "icalBuddy", "-nc", "-nrd", "-b", "@@", "-ps", "|;;|",
+            "-iep", "datetime,title,notes",
+            "-df", "%Y-%m-%d", "-tf", "%H:%M", "-ea",
+            "eventsToday",
+        ],
+        timeout=30,
+    )
+    if not out:
+        print("今日の予定はありません")
+        pause()
+        return 0
+
+    now = datetime.now()
+    lines = []
+    urls = {}
+    seen = set()
+    for block in out.split("@@"):
+        if not block.strip():
+            continue
+        fields = block.split(";;")
+        title = fields[0].strip().replace("\n", " ")
+        when = fields[-1].strip() if len(fields) > 1 else ""
+        body = ";;".join(fields[1:-1]) if len(fields) > 2 else ""
+
+        times = re.findall(r"(\d{2}:\d{2})", when)
+        span = f"{times[0]}-{times[1]}" if len(times) > 1 else (times[0] if times else "")
+
+        # 会議室の URL を優先して拾う
+        meeting = ""
+        for pattern in (r"https://meet\.google\.com/\S+", r"https://\S*zoom\.us/\S+",
+                        r"https://teams\.microsoft\.com/\S+"):
+            found = re.search(pattern, body)
+            if found:
+                meeting = found.group(0).rstrip('">,')
+                break
+
+        marker = " "
+        if len(times) > 1:
+            try:
+                start = datetime.combine(now.date(), datetime.strptime(times[0], "%H:%M").time())
+                end = datetime.combine(now.date(), datetime.strptime(times[1], "%H:%M").time())
+                if start <= now < end:
+                    marker = ">"  # 進行中
+                elif end <= now:
+                    marker = "-"  # 終わった
+            except ValueError:
+                pass
+
+        # 複数のカレンダーに同じ予定が入っていることがある
+        if (span, title) in seen:
+            continue
+        seen.add((span, title))
+
+        link = " [link]" if meeting else ""
+        line = f"{marker} {pad(span, 12)} {pad(title, 46)}{link}"
+        lines.append(line)
+        urls[line] = meeting
+
+    if not lines:
+        print("今日の予定はありません")
+        pause()
+        return 0
+
+    selected = choose(lines)
+    if selected:
+        open_url(urls.get(selected, ""))
+    return 0
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    target = sys.argv[1]
+    if target in ("github", "gh"):
+        return github()
+    if target in ("calendar", "cal"):
+        return calendar()
+    print(f"不明な対象: {target}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/tmux-status-right
+++ b/bin/tmux-status-right
@@ -410,12 +410,9 @@ def compose(results, icons, icons_plain):
     order = [name for name, _ in SEGMENTS]
     chosen.sort(key=lambda item: order.index(item[0]))
 
-    # クリックできるセグメント (tmux の range=user)。名前は 15 バイトまで
-    CLICKABLE = {"github": "gh", "calendar": "cal"}
-
     out = ""
     previous_bg = BAR_BG
-    for name, text, style in chosen:
+    for _, text, style in chosen:
         fg, bg = STYLES[style]
         if icons_plain:
             head = f"#[fg={fg},bg={bg}]{SEP_PLAIN}"
@@ -424,12 +421,7 @@ def compose(results, icons, icons_plain):
             head = f"#[fg=colour240,bg={bg}]{SEP_THIN}#[fg={fg},bg={bg}]"
         else:
             head = f"#[fg={bg},bg={previous_bg}]{SEP}#[fg={fg},bg={bg}]"
-        clickable = CLICKABLE.get(name)
-        if clickable:
-            # クリックすると MouseDown1Status が起き、mouse_status_range にこの名前が入る
-            out += f"#[range=user|{clickable}]{head} {text} #[norange]"
-        else:
-            out += f"{head} {text} "
+        out += f"{head} {text} "
         previous_bg = bg
     # 時計セグメントの手前まで。日付は曜日を英語で出したいのでここで組み立てる
     # (tmux 組み込みの strftime はサーバのロケールに従うため %a が「水」になる)

--- a/bin/tmux-status-right
+++ b/bin/tmux-status-right
@@ -410,9 +410,12 @@ def compose(results, icons, icons_plain):
     order = [name for name, _ in SEGMENTS]
     chosen.sort(key=lambda item: order.index(item[0]))
 
+    # クリックできるセグメント (tmux の range=user)。名前は 15 バイトまで
+    CLICKABLE = {"github": "gh", "calendar": "cal"}
+
     out = ""
     previous_bg = BAR_BG
-    for _, text, style in chosen:
+    for name, text, style in chosen:
         fg, bg = STYLES[style]
         if icons_plain:
             head = f"#[fg={fg},bg={bg}]{SEP_PLAIN}"
@@ -421,7 +424,12 @@ def compose(results, icons, icons_plain):
             head = f"#[fg=colour240,bg={bg}]{SEP_THIN}#[fg={fg},bg={bg}]"
         else:
             head = f"#[fg={bg},bg={previous_bg}]{SEP}#[fg={fg},bg={bg}]"
-        out += f"{head} {text} "
+        clickable = CLICKABLE.get(name)
+        if clickable:
+            # クリックすると MouseDown1Status が起き、mouse_status_range にこの名前が入る
+            out += f"#[range=user|{clickable}]{head} {text} #[norange]"
+        else:
+            out += f"{head} {text} "
         previous_bg = bg
     # 時計セグメントの手前まで。日付は曜日を英語で出したいのでここで組み立てる
     # (tmux 組み込みの strftime はサーバのロケールに従うため %a が「水」になる)


### PR DESCRIPTION
## 概要

GitHub の未読通知と今日の予定を tmux のポップアップで開けるようにしました。左に一覧、右に詳細という `fprwtree` と同じ見せ方です。

| キー | 開くもの |
| --- | --- |
| `prefix + g` | 未読の GitHub 通知。Enter でブラウザを開く |
| `prefix + a` | 今日の予定。Enter で会議 URL を開く |

```
┌─ 通知 > ───────────────────────────────────┬──────────────────────────┐
│  10/10                                      │ リポジトリ : standandforce/…│
│  Enter でブラウザを開く / Esc で閉じる           │ 種別       : PullRequest  │
│ ▌standandforce/dresscode-bac… feat(shared…  │ 理由       : review_reque…│
│ ▌cottpan/dotfiles  CI workflow run failed…  │ 更新       : … (33分前)    │
│                                             │ 状態   : open             │
│                                             │ 作成者 : gamonges          │
└─────────────────────────────────────────────┴──────────────────────────┘
```

fzf が無い環境では一覧を表示してキー入力を待ちます。

## 詳細ペインの中身

**GitHub 通知** — リポジトリ・種別・理由・更新時刻・タイトルは即座に表示します。状態・作成者・本文は**カーソルを合わせた項目だけ**取りに行き、結果をキャッシュします。通知が 10 件あるからといって 10 回 API を叩くのは避けたいためです。

**今日の予定** — 時間・状態 (進行中 `>` / 終了 `-` / これから)・会議 URL・メモを表示します。Google Meet の電話番号などはメモに入っているので、HTML タグを落として読める形にしています。

```
予定   : ITF朝会
時間   : 10:30-11:00
状態   : 終了
会議室 : https://meet.google.com/thv-ceou-tnk

--- メモ ---
Google Meet に参加: https://meet.google.com/thv-ceou-tnk
電話で参加: (JP) +81 3-4545-0450 PIN: ...
```

icalBuddy の出力は **notes が複数行にまたがり、日時がブロック末尾に来る**ため、行単位ではなくイベント単位 (`-b "@@"` で区切る) で解析しています。複数カレンダーに同じ予定が入っている場合の重複も除きます。

## クリックで開く案について

当初はステータスバーのセグメントをクリックする形を目指しましたが、**tmux の仕様上できませんでした。**

`#[range=user|X]` は **`status-format` に直接書いたものしか登録されず、`status-right` の `#()` 出力に入れても無視されます**。クリックのログを 2 度取って確認しています。

```
1回目 (外側の range=right あり) : MouseDown1StatusRight  range=[right]
2回目 (外側の range=right を除去): MouseDown1StatusDefault range=[]      ← セグメント名が入らない
```

マウスの x 座標から判定する方式も試しましたが、この環境では**ステータス右側が右端に寄っておらず** (画面幅 422 に対し右端が x=123)、位置の前提が崩れていました。`status-right-length` と `status-left` はいずれも無罪で、既定設定のネスト tmux では同じ内容が正しく右寄せされるため、原因は特定しきれていません。

クリックを実現するなら、右側のセグメントを 1 つずつ `status-format` に `#()` として並べ、その周りに `range=user` を書く形へ組み替える必要があります。ステータス行の組み立て方を変える規模になるため、この PR では確実に動くキー操作にしました。

## 動作確認

- `prefix + g` で通知 10 件の一覧と右側の詳細 (種別・理由・更新・タイトル・状態・作成者) が描画されることを実機で確認
- `prefix + a` で予定 5 件が進行中/終了のマーカー付きで並ぶことを確認
- `--detail` の遅延取得が本文を取得しキャッシュすることを確認
- `make test` 159 成功 / 0 失敗 / 2 スキップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)