### PR TITLE
feat(tmux): add tmux and Neovim cheat sheets

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -158,6 +158,11 @@ bind C run-shell '~/bin/tmux-workspace "#{pane_current_path}"'
 bind g display-popup -E -w 85% -h 60% '~/bin/tmux-status-popup github'
 bind a display-popup -E -w 70% -h 50% '~/bin/tmux-status-popup calendar'
 
+# チートシート (どちらも fzf で絞り込める)
+# ? は既定のキー一覧 (list-keys) を置き換える。生の一覧は :list-keys で見られる
+bind ? display-popup -E -w 80% -h 70% '~/bin/cheatsheet tmux'
+bind v display-popup -E -w 80% -h 70% '~/bin/cheatsheet nvim'
+
 # 設定のリロード (既定の refresh-client は prefix + R に退避)
 bind r source-file ~/.tmux.conf \; display-message "sourced ~/.tmux.conf"
 bind R refresh-client

--- a/bin/cheatsheet
+++ b/bin/cheatsheet
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""tmux と Neovim のチートシートをポップアップで開く。
+
+    cheatsheet tmux      tmux のキー操作
+    cheatsheet nvim      Neovim のキー操作
+    cheatsheet tmux --list   一覧をそのまま出す (テスト用)
+
+内容は etc/cheatsheet/*.tsv に置いてある。列は
+「セクション / キー / 概要 / 詳細 / 出所(custom=この dotfiles で定義, builtin=標準)」。
+
+fzf があればセクション込みで絞り込めて、右側に詳細が出る。無ければ一覧を表示するだけ。
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unicodedata
+from pathlib import Path
+
+DOTPATH = Path(os.path.realpath(__file__)).parent.parent
+DATA_DIR = DOTPATH / "etc" / "cheatsheet"
+
+TITLES = {"tmux": "tmux", "nvim": "Neovim"}
+
+
+def have(command):
+    return any(
+        os.access(os.path.join(path, command), os.X_OK)
+        for path in os.environ.get("PATH", "").split(os.pathsep)
+        if path
+    )
+
+
+def display_width(text):
+    return sum(2 if unicodedata.east_asian_width(c) in ("W", "F") else 1 for c in text)
+
+
+def pad(text, columns):
+    width = display_width(text)
+    if width > columns:
+        out = ""
+        acc = 0
+        for char in text:
+            step = 2 if unicodedata.east_asian_width(char) in ("W", "F") else 1
+            if acc + step > columns - 1:
+                break
+            out += char
+            acc += step
+        return out + "…"
+    return text + " " * (columns - width)
+
+
+def load(target):
+    path = DATA_DIR / f"{target}.tsv"
+    rows = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip() or line.startswith("#"):
+            continue
+        fields = line.split("\t")
+        # detail と source は省略できる
+        fields += [""] * (5 - len(fields))
+        rows.append(fields[:5])
+    return rows
+
+
+def render(rows):
+    """一覧の行と、右側に出す詳細を作る。"""
+    items = []
+    for section, keys, summary, detail, source in rows:
+        line = f"{pad(section, 14)} {pad(keys, 22)} {summary}"
+        note = "この dotfiles で定義したキー" if source == "custom" else "Neovim / tmux の標準のキー"
+        text = f"[{section}]\n\n{keys}\n\n{summary}\n"
+        if detail:
+            text += f"\n{detail}\n"
+        text += f"\n---\n{note}\n"
+        items.append((line, text))
+    return items
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] not in TITLES:
+        print(__doc__)
+        return 2
+    target = sys.argv[1]
+    rows = load(target)
+    items = render(rows)
+
+    if "--list" in sys.argv or not have("fzf"):
+        print("\n".join(line for line, _ in items))
+        return 0
+
+    workdir = tempfile.mkdtemp(prefix="cheatsheet-")
+    try:
+        lines = []
+        for index, (line, text) in enumerate(items):
+            (Path(workdir) / str(index)).write_text(text, encoding="utf-8")
+            lines.append(f"{index}\t{line}")
+        subprocess.run(
+            [
+                "fzf",
+                "--delimiter", "\t",
+                "--with-nth", "2..",
+                "--prompt", f"{TITLES[target]} > ",
+                "--header", "キーやセクション名で絞り込み / Esc で閉じる",
+                "--preview", f"cat {workdir}/{{1}}",
+                "--preview-window", "right:45%,wrap",
+                "--reverse",
+                "--border",
+                "--no-sort",
+            ],
+            input="\n".join(lines) + "\n",
+            text=True,
+            check=False,
+        )
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/etc/cheatsheet/nvim.tsv
+++ b/etc/cheatsheet/nvim.tsv
@@ -1,0 +1,52 @@
+# section	keys	summary	detail	source
+モード	i / a	入力を始める (カーソル前 / 後)	Neovim は「入力モード」と「操作モード」が分かれている。Esc で操作モードに戻る。	builtin
+モード	o / O	下 / 上に行を足して入力		builtin
+モード	v / V / C-v	選択 (文字 / 行 / 矩形)		builtin
+モード	Esc	操作モードに戻る	迷ったらまず Esc。	builtin
+モード	:	コマンドを打つ	:w や :q はここから。	builtin
+保存と終了	:w	保存		builtin
+保存と終了	:q	閉じる	変更があると閉じられない。	builtin
+保存と終了	:wq / ZZ	保存して閉じる		builtin
+保存と終了	:q!	保存せずに閉じる		builtin
+移動	h j k l	左 下 上 右	連打すると加速する (accelerated-jk)。	builtin
+移動	w / b	次 / 前の単語へ		builtin
+移動	0 / $	行頭 / 行末へ		builtin
+移動	gg / G	ファイルの先頭 / 末尾へ		builtin
+移動	C-d / C-u	半画面ずつスクロール		builtin
+移動	%	対応する括弧へ		builtin
+移動	C-h / C-l	左 / 右のウィンドウへ		custom
+編集	x / dd	1文字 / 1行を削除	削除した内容はレジスタに入るので p で貼れる。	builtin
+編集	yy / p	1行コピー / 貼り付け		builtin
+編集	u / C-r	取り消し / やり直し		builtin
+編集	cw / ciw	単語を書き換える	ciw はカーソルがある単語全体。	builtin
+編集	.	直前の変更を繰り返す	覚えると効率が上がる。	builtin
+編集	>> / <<	インデントを深く / 浅く		builtin
+検索	/	検索	n で次、N で前。	builtin
+検索	*	カーソル位置の単語を検索		builtin
+検索	Esc Esc	検索のハイライトを消す		custom
+検索	:%s/old/new/g	ファイル全体を置換	確認しながらなら末尾に c を付ける。	builtin
+ファイル	Space e	ファイルツリーを開閉	ツリー内で ? を押すと操作一覧が出る。	custom
+ファイル	Space o	ファイルツリーにフォーカス		custom
+ファイル	Space ff	ファイルを名前で探す		custom
+ファイル	Space fg	ファイルの中身を検索	ripgrep で全文検索。	custom
+ファイル	Space fb	開いているバッファ一覧		custom
+ファイル	Space fh	ヘルプを検索		custom
+コード	gd	定義へ飛ぶ		custom
+コード	gr	参照を一覧		custom
+コード	K	カーソル位置の説明を出す		custom
+コード	Space rn	名前を変更 (リネーム)	参照している箇所もまとめて変わる。	custom
+コード	Space ca	コードアクション (自動修正など)		custom
+コード	Space f	ファイルを整形		custom
+コード	Space gd / gr / gi / gy	定義・参照をプレビュー付きで見る	Glance。飛ばずに中身を確認したい時。	custom
+コード	Space ss / Space sw	シンボルを絞り込んで移動	Namu。関数や変数の一覧から飛ぶ。	custom
+コード	Space ;	パンくずから選んで移動	dropbar。画面上部のパス表示から。	custom
+診断	C-j / C-k	次 / 前の警告・エラーへ		custom
+診断	Space d	カーソル位置の診断を詳しく出す		custom
+診断	Space fd	診断の一覧を検索		custom
+Git	]c / [c	次 / 前の変更箇所へ		custom
+Git	Space hp	変更箇所の差分を見る		custom
+Git	Space hs / Space hr	変更箇所をステージ / 取り消し		custom
+Git	Space hb	その行のコミットを詳しく見る	行末に出ている blame の詳細版。	custom
+Git	Space tb	行ごとの blame 表示を切り替え		custom
+折りたたみ	za	折りたたみを開閉		builtin
+折りたたみ	zR / zM	すべて開く / すべて閉じる		custom

--- a/etc/cheatsheet/tmux.tsv
+++ b/etc/cheatsheet/tmux.tsv
@@ -1,0 +1,43 @@
+# section	keys	summary	detail	source
+基本	C-q	prefix (すべての操作はこれを押してから)	tmux の操作は prefix を押してから次のキーを押す。押している間だけ待ち受け状態になる。	custom
+基本	C-q ?	このチートシート		custom
+基本	C-q d	デタッチ (セッションは残る)	端末を閉じてもセッションは生き続ける。tmux a で戻れる。	builtin
+基本	C-q s	セッション一覧から選ぶ		builtin
+基本	C-q $	セッション名を変更		builtin
+基本	C-q :	tmux のコマンドを入力	list-keys など、キーに割り当てていない操作はここから。	builtin
+基本	C-q r	設定を読み直す	~/.tmux.conf を保存すると自動でも読み直される (entr 監視)。	custom
+基本	C-q C-q	直前のウィンドウへ戻る	prefix の二度押し。	custom
+ウィンドウ	C-q c	新しいウィンドウ	今いるディレクトリを引き継ぐ。	custom
+ウィンドウ	C-q C	作業ウィンドウを開く	エディタ + ターミナル + エージェントの3ペイン構成で開く。	custom
+ウィンドウ	C-q n / C-q p	次 / 前のウィンドウ		builtin
+ウィンドウ	C-q 1 .. C-q 9	番号でウィンドウ移動	番号は 1 始まり。	builtin
+ウィンドウ	C-q w	ウィンドウ一覧から選ぶ		builtin
+ウィンドウ	C-q ,	ウィンドウ名を変更	Claude Code のセッションでは最初の依頼から自動で名前が付く。	builtin
+ウィンドウ	C-q &	ウィンドウを閉じる	確認あり。	builtin
+ウィンドウ	C-q < / C-q >	ウィンドウを左 / 右へ移動	連打できる。	custom
+ウィンドウ	C-q f	ウィンドウを検索して移動		builtin
+ペイン	C-q |	左右に分割	今いるペインだけを分割。カレントパスを引き継ぐ。	custom
+ペイン	C-q -	上下に分割	今いるペインだけを分割。	custom
+ペイン	C-q \\ / C-q _	画面全体で左右 / 上下に分割	ペイン単位ではなくウィンドウ全体を分ける。押し間違えに注意。	custom
+ペイン	C-q h j k l	ペイン間を移動	vim と同じ向き。	custom
+ペイン	C-q H J K L	ペインの大きさを変える	連打できる。	custom
+ペイン	C-q z	ペインを最大化 / 戻す	最大化中はタブに虫眼鏡が出る。	builtin
+ペイン	C-q x	ペインを閉じる	確認あり。	builtin
+ペイン	C-q !	ペインを別ウィンドウに切り出す		builtin
+ペイン	C-q q	ペイン番号を表示	表示中に番号を押すとそのペインへ移動。	builtin
+ペイン	C-q o	次のペインへ		builtin
+ペイン	C-q space	レイアウトを切り替える		builtin
+コピー	C-q [	コピーモードに入る	スクロールや選択はこのモードで行う。q で抜ける。	builtin
+コピー	v	選択を開始 (コピーモード中)	vim と同じ操作感。	custom
+コピー	C-v	矩形選択に切り替え (コピーモード中)		custom
+コピー	y	選択範囲をコピー (コピーモード中)	システムのクリップボードに入る。	custom
+コピー	Enter	選択範囲をコピーして抜ける		custom
+コピー	C-q ]	貼り付け		builtin
+コピー	C-q y / C-q Y	コマンドライン / カレントパスをコピー		custom
+ポップアップ	C-q g	GitHub の未読通知	Enter でブラウザを開く。	custom
+ポップアップ	C-q a	今日の予定	Enter で会議 URL を開く。	custom
+ポップアップ	C-q v	Neovim のチートシート		custom
+セッション保存	C-q C-s	セッションを保存	ウィンドウ・ペイン構成を保存する (resurrect)。	custom
+セッション保存	C-q C-r	セッションを復元		custom
+プラグイン	C-q I	プラグインを導入	TPM。.tmux.conf に @plugin を足した後に押す。	custom
+プラグイン	C-q U	プラグインを更新		custom

--- a/test/suite/30-runtime.sh
+++ b/test/suite/30-runtime.sh
@@ -166,6 +166,47 @@ else
     skip "tmux の設定値" "tmux が無い"
 fi
 
+# --- チートシート -----------------------------------------------------------
+
+for target in tmux nvim; do
+    if output=$("$DOTPATH/bin/cheatsheet" "$target" --list 2>&1) && [ -n "$output" ]; then
+        ok "チートシートが出る ($target)"
+    else
+        fail "チートシートが出る ($target)" "$output"
+    fi
+done
+
+# 列が欠けていないか (セクション・キー・概要は必須)
+if have python3; then
+    check "チートシートの表が壊れていない" python3 -c "
+import sys, pathlib
+for name in ('tmux', 'nvim'):
+    path = pathlib.Path('$DOTPATH/etc/cheatsheet/%s.tsv' % name)
+    for number, line in enumerate(path.read_text(encoding='utf-8').splitlines(), 1):
+        if not line.strip() or line.startswith('#'):
+            continue
+        fields = line.split('\t')
+        if len(fields) < 3 or not all(fields[:3]):
+            sys.exit('%s:%d 列が足りない: %s' % (path.name, number, line))
+"
+else
+    skip "チートシートの表の検証" "python3 が無い"
+fi
+
+if have tmux; then
+    socket="dotfiles-test-cheat-$$"
+    tmux -L "$socket" -f "$DOTPATH/.tmux.conf" new-session -d -x 80 -y 24 2> /dev/null
+    assigned=$(tmux -L "$socket" list-keys -T prefix 2> /dev/null | grep -c "cheatsheet")
+    if [ "$assigned" -ge 2 ]; then
+        ok "チートシートのキーが割り当たっている (tmux / nvim)"
+    else
+        fail "チートシートのキーが割り当たっている (tmux / nvim)" "見つかった数: $assigned"
+    fi
+    tmux -L "$socket" kill-server 2> /dev/null || true
+else
+    skip "チートシートのキー割り当て" "tmux が無い"
+fi
+
 # --- bin のスモークテスト ---------------------------------------------------
 
 if have tmux; then


### PR DESCRIPTION
## 概要

tmux と Neovim のキー操作をポップアップで引けるようにしました。セクションごとに並び、fzf で絞り込めて、右側に説明が出ます。

| キー | 開くもの |
| --- | --- |
| `prefix + ?` | tmux のチートシート (42 項目) |
| `prefix + v` | Neovim のチートシート (51 項目) |

```
┌─ tmux > ───────────────────────────────────────┬──────────────────────────────┐
│  42/42                                          │ [基本]                        │
│  キーやセクション名で絞り込み / Esc で閉じる            │                              │
│ ▌基本      C-q          prefix (すべての操作は…)   │ C-q                          │
│ ▌基本      C-q ?        このチートシート             │                              │
│ ▌基本      C-q d        デタッチ (セッションは残る)   │ prefix (すべての操作はこれを押して…) │
│ ▌ウィンドウ C-q c        新しいウィンドウ             │                              │
│ ▌ペイン    C-q |        左右に分割                 │ tmux の操作は prefix を押して… │
│                                                 │ ---                          │
│                                                 │ この dotfiles で定義したキー      │
└─────────────────────────────────────────────────┴──────────────────────────────┘
```

## 内容

`etc/cheatsheet/*.tsv` に「セクション / キー / 概要 / 詳細 / 出所」で置いてあります。**出所の列**は、そのキーがこの dotfiles で定義したものか tmux・Neovim の標準かを示します。他所の記事を読んでいて「このキーは自分の設定なのか標準なのか」が分かるようにするためです。

この dotfiles で定義したキー (`C-q |` の分割、`C-q C` の作業ウィンドウ、`Space ff` の検索、`Space hb` の blame など) に加えて、**初心者がまず必要になる標準キー**も入れています。

- tmux: デタッチ、セッション一覧、コピーモード、ズーム、ペイン番号表示
- Neovim: モードの切り替え、保存と終了、基本の移動、`dd` / `yy` / `p` / `u`、検索と置換

`prefix + ?` は既定の `list-keys` を置き換えます。正確ではあるものの、コマンドの羅列で初見では読みにくいためです。生の一覧は `:list-keys` で従来どおり見られます。

## テスト

runtime スイートに 4 項目を追加しました。

- 両方のチートシートが出力を返すか
- 表の列が欠けていないか (セクション・キー・概要は必須)
- `prefix + ?` と `prefix + v` が割り当たったままか

`make test` は 163 成功 / 0 失敗 / 2 スキップです。

## 動作確認

tmux 上で実際に開いて、一覧・絞り込み・右側の説明が表示されることを確認しました (tmux 42 項目 / Neovim 51 項目)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)