### PR TITLE
feat(tmux): open Claude in a popup for quick questions

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -158,6 +158,11 @@ bind C run-shell '~/bin/tmux-workspace "#{pane_current_path}"'
 bind g display-popup -E -w 85% -h 60% '~/bin/tmux-status-popup github'
 bind a display-popup -E -w 70% -h 50% '~/bin/tmux-status-popup calendar'
 
+# ちょっと聞きたいとき用に Claude を開く
+# 開いた場所のディレクトリで動かすので、そのプロジェクトの話がそのまま通じる。
+# その場限りの質問でウィンドウ名が変わると困るので、名前を付けるフックは止める
+bind A display-popup -E -w 85% -h 85% -d '#{pane_current_path}' 'CLAUDE_TMUX_TITLE_SKIP=1 ${CLAUDE_POPUP_COMMAND:-claude}'
+
 # チートシート (どちらも fzf で絞り込める)
 # ? は既定のキー一覧 (list-keys) を置き換える。生の一覧は :list-keys で見られる
 bind ? display-popup -E -w 80% -h 70% '~/bin/cheatsheet tmux'

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -160,7 +160,9 @@ bind a display-popup -E -w 70% -h 50% '~/bin/tmux-status-popup calendar'
 
 # ちょっと聞きたいとき用に Claude を開く
 # 開いた場所のディレクトリで動かすので、そのプロジェクトの話がそのまま通じる。
-# その場限りの質問でウィンドウ名が変わると困るので、名前を付けるフックは止める
+# その場限りの質問でウィンドウ名が変わると困るので、名前を付けるフックは止める。
+# 閉じるのは /exit か C-d か C-c 2 回。ポップアップ表示中は prefix も Escape も
+# 中のプログラムが受け取るため、tmux 側から閉じるキーは用意できない
 bind A display-popup -E -w 85% -h 85% -d '#{pane_current_path}' 'CLAUDE_TMUX_TITLE_SKIP=1 ${CLAUDE_POPUP_COMMAND:-claude}'
 
 # チートシート (どちらも fzf で絞り込める)

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -158,12 +158,15 @@ bind C run-shell '~/bin/tmux-workspace "#{pane_current_path}"'
 bind g display-popup -E -w 85% -h 60% '~/bin/tmux-status-popup github'
 bind a display-popup -E -w 70% -h 50% '~/bin/tmux-status-popup calendar'
 
-# ちょっと聞きたいとき用に Claude を開く
-# 開いた場所のディレクトリで動かすので、そのプロジェクトの話がそのまま通じる。
-# その場限りの質問でウィンドウ名が変わると困るので、名前を付けるフックは止める。
-# 閉じるのは /exit か C-d か C-c 2 回。ポップアップ表示中は prefix も Escape も
-# 中のプログラムが受け取るため、tmux 側から閉じるキーは用意できない
-bind A display-popup -E -w 85% -h 85% -d '#{pane_current_path}' 'CLAUDE_TMUX_TITLE_SKIP=1 ${CLAUDE_POPUP_COMMAND:-claude}'
+# ちょっと聞きたいとき用に Claude を開く / 隠す (同じキーで切り替わる)
+# ポップアップの中は専用セッションに繋いだ tmux クライアントなので、
+# もう一度押すと detach するだけで済み、会話は残ったまま次に開くと続きから使える。
+# (claude を直接動かすと、閉じる = 終了になってしまう)
+bind A if -F '#{==:#{session_name},_claude}' {
+    detach-client
+} {
+    display-popup -E -w 85% -h 85% -d '#{pane_current_path}' '~/bin/tmux-claude-scratch'
+}
 
 # チートシート (どちらも fzf で絞り込める)
 # ? は既定のキー一覧 (list-keys) を置き換える。生の一覧は :list-keys で見られる

--- a/bin/tmux-claude-scratch
+++ b/bin/tmux-claude-scratch
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+# ポップアップから Claude に繋ぐ。セッションは残したまま隠せるようにする。
+#
+# display-popup で claude を直接動かすと、閉じる = 終了になってしまう。
+# 専用のセッションを立ててそこに attach する形にすると、detach するだけで
+# ポップアップが閉じ、会話はそのまま残る。次に開くと続きから使える。
+#
+# 隠すのは .tmux.conf 側の bind (同じキーで detach-client) が担当する。
+
+set -eu
+
+session=${TMUX_CLAUDE_SESSION:-_claude}
+command=${CLAUDE_POPUP_COMMAND:-claude}
+
+# $TMUX は "ソケット,PID,セッション番号"。入れ子で繋ぐときに TMUX を外すので、
+# どのサーバだったかをここで控えておく (外すと既定のソケットを見に行ってしまう)
+socket=""
+if [ -n "${TMUX:-}" ]; then
+    socket=${TMUX%%,*}
+fi
+
+tmux_cmd() {
+    if [ -n "$socket" ]; then
+        tmux -S "$socket" "$@"
+    else
+        tmux "$@"
+    fi
+}
+
+if ! tmux_cmd has-session -t "=$session" 2> /dev/null; then
+    # ウィンドウ名を付けるフックは止める (この場限りの質問で名前が変わると困る)
+    tmux_cmd new-session -d -s "$session" -e CLAUDE_TMUX_TITLE_SKIP=1 "$command"
+    # set-option は "=" 付きのセッション指定を受け付けないので、そのまま渡す
+    # ポップアップの中に status 行は要らない
+    tmux_cmd set-option -t "$session" status off
+    # 隠している間 (detach 中) もセッションを残す
+    tmux_cmd set-option -t "$session" destroy-unattached off
+fi
+
+# 同じサーバへの入れ子になるので、TMUX を外してから繋ぐ
+unset TMUX
+if [ -n "$socket" ]; then
+    exec tmux -S "$socket" attach-session -t "=$session"
+fi
+exec tmux attach-session -t "=$session"

--- a/bin/tmux-status-right
+++ b/bin/tmux-status-right
@@ -79,7 +79,8 @@ STYLES = {
     "claude_stale": ("colour240", "colour236"),
     "github": ("colour136", "colour238"),
     "calendar": ("colour37", "colour238"),
-    "calendar_now": ("colour160", "colour238"),  # 進行中は赤で目立たせる
+    # 進行中は反転させる。暗い背景に暗い赤 (colour160) だとコントラストが 1.8 しかなく読めない
+    "calendar_now": ("colour235", "colour203"),
     "clock": ("colour235", "colour136"),
 }
 

--- a/etc/cheatsheet/tmux.tsv
+++ b/etc/cheatsheet/tmux.tsv
@@ -37,7 +37,7 @@
 ポップアップ	C-q g	GitHub の未読通知	Enter でブラウザを開く。	custom
 ポップアップ	C-q a	今日の予定	Enter で会議 URL を開く。	custom
 ポップアップ	C-q v	Neovim のチートシート		custom
-ポップアップ	C-q A	Claude にちょっと聞く	開いた場所のディレクトリで起動する。閉じるには /exit か C-d、または C-c を 2 回。Esc では閉じない (Claude 側がキーを受け取るため)。	custom
+ポップアップ	C-q A	Claude を開く / 隠す	同じキーで切り替わる。隠しても会話は残るので、次に開くと続きから使える。終了したいときは中で /exit か C-d。	custom
 セッション保存	C-q C-s	セッションを保存	ウィンドウ・ペイン構成を保存する (resurrect)。	custom
 セッション保存	C-q C-r	セッションを復元		custom
 プラグイン	C-q I	プラグインを導入	TPM。.tmux.conf に @plugin を足した後に押す。	custom

--- a/etc/cheatsheet/tmux.tsv
+++ b/etc/cheatsheet/tmux.tsv
@@ -37,7 +37,7 @@
 ポップアップ	C-q g	GitHub の未読通知	Enter でブラウザを開く。	custom
 ポップアップ	C-q a	今日の予定	Enter で会議 URL を開く。	custom
 ポップアップ	C-q v	Neovim のチートシート		custom
-ポップアップ	C-q A	Claude にちょっと聞く	開いた場所のディレクトリで起動する。終わるときは /exit か C-d。	custom
+ポップアップ	C-q A	Claude にちょっと聞く	開いた場所のディレクトリで起動する。閉じるには /exit か C-d、または C-c を 2 回。Esc では閉じない (Claude 側がキーを受け取るため)。	custom
 セッション保存	C-q C-s	セッションを保存	ウィンドウ・ペイン構成を保存する (resurrect)。	custom
 セッション保存	C-q C-r	セッションを復元		custom
 プラグイン	C-q I	プラグインを導入	TPM。.tmux.conf に @plugin を足した後に押す。	custom

--- a/etc/cheatsheet/tmux.tsv
+++ b/etc/cheatsheet/tmux.tsv
@@ -37,6 +37,7 @@
 ポップアップ	C-q g	GitHub の未読通知	Enter でブラウザを開く。	custom
 ポップアップ	C-q a	今日の予定	Enter で会議 URL を開く。	custom
 ポップアップ	C-q v	Neovim のチートシート		custom
+ポップアップ	C-q A	Claude にちょっと聞く	開いた場所のディレクトリで起動する。終わるときは /exit か C-d。	custom
 セッション保存	C-q C-s	セッションを保存	ウィンドウ・ペイン構成を保存する (resurrect)。	custom
 セッション保存	C-q C-r	セッションを復元		custom
 プラグイン	C-q I	プラグインを導入	TPM。.tmux.conf に @plugin を足した後に押す。	custom

--- a/test/suite/30-runtime.sh
+++ b/test/suite/30-runtime.sh
@@ -202,6 +202,15 @@ if have tmux; then
     else
         fail "チートシートのキーが割り当たっている (tmux / nvim)" "見つかった数: $assigned"
     fi
+
+    # ポップアップで開くもの (通知 / 予定 / Claude)
+    for popup in tmux-status-popup CLAUDE_POPUP_COMMAND; do
+        if tmux -L "$socket" list-keys -T prefix 2> /dev/null | grep -q "$popup"; then
+            ok "ポップアップのキーが割り当たっている ($popup)"
+        else
+            fail "ポップアップのキーが割り当たっている ($popup)"
+        fi
+    done
     tmux -L "$socket" kill-server 2> /dev/null || true
 else
     skip "チートシートのキー割り当て" "tmux が無い"

--- a/test/suite/30-runtime.sh
+++ b/test/suite/30-runtime.sh
@@ -204,7 +204,7 @@ if have tmux; then
     fi
 
     # ポップアップで開くもの (通知 / 予定 / Claude)
-    for popup in tmux-status-popup CLAUDE_POPUP_COMMAND; do
+    for popup in tmux-status-popup tmux-claude-scratch; do
         if tmux -L "$socket" list-keys -T prefix 2> /dev/null | grep -q "$popup"; then
             ok "ポップアップのキーが割り当たっている ($popup)"
         else


### PR DESCRIPTION
## 概要

`prefix + A` (Ask) で Claude をポップアップで開き、**同じキーでもう一度押すと隠せる**ようにしました。隠している間も会話は残るので、次に開くと続きから使えます。

```
prefix + A  →  開く
prefix + A  →  隠す (会話は残る)
prefix + A  →  続きから開く
```

終了したいときはポップアップの中で `/exit` か `C-d` です。

## 仕組み

`display-popup` で `claude` を直接動かすと、閉じる = 終了になってしまいます。そこで**専用セッション (`_claude`) を立てて、ポップアップからはそこに attach する**形にしました。detach すればポップアップは閉じますが、セッションは残ります。

```tmux
bind A if -F '#{==:#{session_name},_claude}' {
    detach-client
} {
    display-popup -E -w 85% -h 85% -d '#{pane_current_path}' '~/bin/tmux-claude-scratch'
}
```

ポップアップの中身が tmux クライアントなので、同じキーが「開く」と「隠す」の両方を担えます。**キーで閉じる方法は実質これしかありません** — 対話プログラムがポップアップで動いている間は、Escape も tmux の prefix も含めて全てのキーが中のプログラムに渡るためです (実測で確認)。

## 実装でハマった点

- **`unset TMUX` するとソケットの情報も失われる**。入れ子で attach するには TMUX を外す必要がありますが、そのまま `tmux attach` すると既定のサーバを見に行ってしまうため、事前に `${TMUX%%,*}` でソケットを控えて `-S` で渡しています
- **`set-option` は `=name` 形式のセッション指定を受け付けない**。`has-session` や `attach-session` は受け付けるので気づきにくく、`no such session: =_claude` で失敗していました

## その他

- 開いた場所のディレクトリで起動するので、目の前のコードについてそのまま聞けます (セッション作成時のみ)
- その場限りの質問でウィンドウ名が変わらないよう、名前を付けるフックは止めています
- `CLAUDE_POPUP_COMMAND` で起動コマンドを、`TMUX_CLAUDE_SESSION` でセッション名を変えられます
- ポップアップ内に status 行は出しません

## 動作確認

ネストした tmux で、開く → 同じキーで隠す (セッションは残存) → もう一度開くと同じ内容に戻る、を確認しました。チートシート (`prefix + ?`) にも項目があります。

`make test` は 172 成功 / 0 失敗 / 2 スキップです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)