### PR TITLE
feat(install): install on Ubuntu as well as Fedora

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 jobs:
-  # 構文チェックと、隔離した HOME へのデプロイ。macOS と Fedora の両方で回す
+  # 構文チェックと、隔離した HOME へのデプロイ。macOS / Fedora / Ubuntu で回す
   checks:
     name: 静的チェックとデプロイ (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
@@ -18,19 +18,23 @@ jobs:
         include:
           - name: macOS
             os: macos-latest
+            setup: brew install shellcheck
           - name: Fedora
             os: ubuntu-latest
             container: fedora:latest
+            setup: dnf install -y git make zsh ShellCheck python3 file findutils
+          - name: Ubuntu
+            os: ubuntu-latest
+            container: ubuntu:latest
+            setup: >-
+              apt-get update &&
+              DEBIAN_FRONTEND=noninteractive apt-get install -y
+              git make zsh shellcheck python3 file findutils
     steps:
       - uses: actions/checkout@v4
 
-      - name: 必要なコマンドを入れる (Fedora)
-        if: matrix.container != ''
-        run: dnf install -y git make zsh ShellCheck python3 file findutils
-
-      - name: 必要なコマンドを入れる (macOS)
-        if: matrix.container == ''
-        run: brew install shellcheck
+      - name: 必要なコマンドを入れる
+        run: ${{ matrix.setup }}
 
       # コンテナ内は checkout の所有者と実行ユーザが異なり、git が警告を出して止まる
       - name: リポジトリを git の安全なディレクトリに登録する

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 ## Installation
 
-### macOS / Fedora
+### macOS / Fedora / Ubuntu
 ```bash
 bash -c "$(curl -fsSL https://bit.ly/3X8YDzE)"
 ```
 
-Fedora では `sudo` 権限が必要です（`dnf` でパッケージをインストールします）。
+Linux では `sudo` 権限が必要です（Fedora は `dnf`、Ubuntu は `apt` でパッケージを
+インストールします）。Ubuntu は Debian 系の派生（Linux Mint など）も同じ経路で入ります。
+
+Ubuntu の apt に入っている Neovim はプラグインの要求（0.11 以降）より古いことが
+多いため、足りない場合は公式ビルドを `~/.local/nvim` に展開して `~/.local/bin/nvim`
+から参照します。`gh` は標準リポジトリに無いので、GitHub 公式の apt リポジトリを追加します。
+
 インストール後、ログインシェルを zsh に変更してください。
 
 ```bash
@@ -38,5 +44,5 @@ make test-runtime   # このマシンで実際に動くかを見る
 道具が入っていない環境では該当項目を skip するので、どの環境でも走ります。
 `deploy` は `HOME` を一時ディレクトリに差し替えて実行するため、実際のホームディレクトリには触れません。
 
-CI では macOS と Fedora コンテナの両方で `syntax` と `deploy` を回し、
+CI では macOS と Fedora / Ubuntu コンテナで `syntax` と `deploy` を回し、
 macOS では加えて `install.sh` を最初から流したうえで `runtime` を確認しています。

--- a/etc/init/install.sh
+++ b/etc/init/install.sh
@@ -25,6 +25,20 @@ is_fedora() {
     fi
 }
 
+# Ubuntu 本体と、その派生 (Linux Mint など) / Debian もまとめて見る
+is_ubuntu() {
+    if [ -f /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        case "${ID:-}|${ID_LIKE:-}" in
+            ubuntu\|* | debian\|* | *ubuntu* | *debian*) return 0 ;;
+            *) return 1 ;;
+        esac
+    else
+        return 1
+    fi
+}
+
 if [ -n "$CI" ] ; then
     DOTPATH=$RUNNER_WORKSPACE/dotfiles
 fi
@@ -40,6 +54,9 @@ if is_macos ; then
 elif is_linux && is_fedora ; then
     echo "Fedora detected. Calling Fedora install scripts..."
     source "${DOTPATH}/etc/init/linux/fedora/install"
+elif is_linux && is_ubuntu ; then
+    echo "Ubuntu detected. Calling Ubuntu install scripts..."
+    source "${DOTPATH}/etc/init/linux/ubuntu/install"
 else
     echo "Unsupported OS. Skipping OS-specific package installation."
 fi

--- a/etc/init/linux/ubuntu/install
+++ b/etc/init/linux/ubuntu/install
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# エラーがあったらそこで即終了
+set -eo pipefail
+# Prevent commands misbehaving due to locale differences
+export LC_ALL=C
+
+DOTPATH=${DOTPATH:-$HOME/dotfiles}
+
+if [ -n "$CI" ]; then
+    DOTPATH=$RUNNER_WORKSPACE/dotfiles
+fi
+
+# apt が tzdata などで対話プロンプトを出すと止まってしまう
+export DEBIAN_FRONTEND=noninteractive
+# 自前で入れるもの (Neovim / fd / bat) の置き場。.zshenv も PATH の先頭に入れる
+export PATH="$HOME/.local/bin:$PATH"
+
+# リリースによって無いパッケージがある。apt-get は名前を一つでも解決できないと
+# 何も入れずに終わるので、実在するものだけを渡す
+apt_available() {
+    apt-cache show "$1" > /dev/null 2>&1
+}
+
+ubuntu_java_devel_package() {
+    local pkg
+    for pkg in openjdk-25-jdk openjdk-21-jdk openjdk-17-jdk default-jdk; do
+        if apt_available "$pkg"; then
+            echo "$pkg"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Ubuntu の標準リポジトリに gh は無いので、GitHub 公式のリポジトリを足す
+add_github_cli_repo() {
+    local arch keyring
+    keyring=/etc/apt/keyrings/githubcli-archive-keyring.gpg
+    arch=$(dpkg --print-architecture)
+
+    echo "Adding the GitHub CLI apt repository..."
+    sudo install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg |
+        sudo tee "$keyring" > /dev/null
+    sudo chmod go+r "$keyring"
+    echo "deb [arch=${arch} signed-by=${keyring}] https://cli.github.com/packages stable main" |
+        sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    sudo apt-get update
+}
+
+# nvim-treesitter の main ブランチなどが 0.11 以降を要求する。
+# Ubuntu の apt に入っているものは古いことが多いので、足りなければ公式ビルドを使う
+NVIM_REQUIRED_MINOR=11
+
+nvim_is_new_enough() {
+    local version major minor
+    command -v nvim > /dev/null 2>&1 || return 1
+    version=$(nvim --version | head -1 | sed -n 's/^NVIM v\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')
+    [ -n "$version" ] || return 1
+    major=${version%%.*}
+    minor=${version#*.}
+    [ "$major" -gt 0 ] && return 0
+    [ "$minor" -ge "$NVIM_REQUIRED_MINOR" ]
+}
+
+install_neovim_release() {
+    local asset url tmp
+    case "$(uname -m)" in
+        x86_64) asset=nvim-linux-x86_64 ;;
+        aarch64 | arm64) asset=nvim-linux-arm64 ;;
+        *)
+            echo "warning: no official Neovim build for $(uname -m)"
+            return 1
+            ;;
+    esac
+
+    url="https://github.com/neovim/neovim/releases/latest/download/${asset}.tar.gz"
+    tmp=$(mktemp -d)
+    echo "Installing Neovim from ${url}..."
+    if ! curl -fsSL "$url" -o "$tmp/nvim.tar.gz"; then
+        rm -rf "$tmp"
+        echo "warning: failed to download Neovim"
+        return 1
+    fi
+
+    rm -rf "$HOME/.local/nvim"
+    mkdir -p "$HOME/.local/nvim" "$HOME/.local/bin"
+    tar -xzf "$tmp/nvim.tar.gz" -C "$HOME/.local/nvim" --strip-components=1
+    ln -sfn "$HOME/.local/nvim/bin/nvim" "$HOME/.local/bin/nvim"
+    rm -rf "$tmp"
+    # apt の古い nvim を先に叩いていると、その場所が hash に残ったままになる
+    hash -r
+}
+
+# Ubuntu は fd / bat を fdfind / batcat という名前で入れる
+link_command_alias() {
+    local want=$1 actual=$2
+    if command -v "$want" > /dev/null 2>&1; then
+        return 0
+    fi
+    if command -v "$actual" > /dev/null 2>&1; then
+        mkdir -p "$HOME/.local/bin"
+        ln -sfn "$(command -v "$actual")" "$HOME/.local/bin/$want"
+    fi
+}
+
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl
+
+if ! apt_available gh; then
+    add_github_cli_repo
+fi
+
+# Brewfile.test に対応する Ubuntu パッケージ。
+# Neovim は下で公式ビルドを入れるのでここには含めない
+CANDIDATE_PACKAGES=(
+    awscli
+    bat
+    colordiff
+    entr
+    fd-find
+    ffmpeg
+    fzf
+    gcc
+    gh
+    git
+    git-delta
+    jq
+    libjxl-tools
+    make
+    ripgrep
+    shellcheck
+    tmux
+    unzip
+    webp
+    yt-dlp
+    zsh
+)
+
+JAVA_DEVEL=$(ubuntu_java_devel_package || true)
+if [ -n "$JAVA_DEVEL" ]; then
+    CANDIDATE_PACKAGES+=("$JAVA_DEVEL")
+else
+    echo "warning: no OpenJDK devel package found in enabled repositories"
+fi
+
+PACKAGES=()
+MISSING=()
+for package in "${CANDIDATE_PACKAGES[@]}"; do
+    if apt_available "$package"; then
+        PACKAGES+=("$package")
+    else
+        MISSING+=("$package")
+    fi
+done
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    echo "warning: not available in enabled repositories: ${MISSING[*]}"
+fi
+
+echo "Installing packages via apt..."
+sudo apt-get install -y "${PACKAGES[@]}"
+
+hash -r
+link_command_alias fd fdfind
+link_command_alias bat batcat
+
+if ! nvim_is_new_enough; then
+    install_neovim_release || true
+fi
+if ! nvim_is_new_enough; then
+    echo "warning: Neovim 0.${NVIM_REQUIRED_MINOR} 以降が必要です (プラグインが動きません)"
+fi
+
+# zplug
+if [ ! -d "$HOME/.zplug" ]; then
+    echo "Installing zplug..."
+    git clone https://github.com/zplug/zplug "$HOME/.zplug"
+fi
+
+# mise (.zshrc で使用)
+if ! command -v mise > /dev/null 2>&1; then
+    echo "Installing mise..."
+    curl -fsSL https://mise.run | sh
+fi
+
+mkdir -p "$HOME/.config/git"
+if [ ! -f "$HOME/.config/git/ignore" ]; then
+    touch "$HOME/.config/git/ignore"
+fi

--- a/etc/init/linux/ubuntu/prerequisites.sh
+++ b/etc/init/linux/ubuntu/prerequisites.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eo pipefail
+export LC_ALL=C
+
+# apt は tzdata などで対話プロンプトを出すので黙らせておく
+export DEBIAN_FRONTEND=noninteractive
+
+echo "Installing Ubuntu prerequisites..."
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl git make
+
+if ! command -v make > /dev/null 2>&1; then
+    echo "error: make is required but not available after apt-get install"
+    exit 1
+fi

--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,29 @@ is_fedora() {
     fi
 }
 
+# Ubuntu 本体と、その派生 (Linux Mint など) / Debian もまとめて見る
+is_ubuntu() {
+    if [ -f /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        case "${ID:-}|${ID_LIKE:-}" in
+            ubuntu\|* | debian\|* | *ubuntu* | *debian*) return 0 ;;
+            *) return 1 ;;
+        esac
+    else
+        return 1
+    fi
+}
+
+# etc/init/linux 以下のどのディレクトリを使うか
+linux_family() {
+    if is_fedora ; then
+        echo "fedora"
+    elif is_ubuntu ; then
+        echo "ubuntu"
+    fi
+}
+
 is_arm() { 
     test "$UNAME" == "arm64"
 }
@@ -80,8 +103,15 @@ elif is_linux ; then
             echo "Installing git..."
             sudo dnf install -y git
         fi
+    elif is_ubuntu ; then
+        echo "Ubuntu detected."
+        if ! command -v git > /dev/null 2>&1; then
+            echo "Installing git..."
+            sudo apt-get update
+            sudo apt-get install -y git
+        fi
     else
-        echo "Unsupported Linux distribution. Abort."
+        echo "Unsupported Linux distribution: ${ID:-unknown}. (Fedora / Ubuntu) Abort."
         exit 1
     fi
 else
@@ -91,17 +121,21 @@ fi
 
 dotfiles_download
 
-if is_fedora && [ -d "${DOTPATH}" ]; then
-    prerequisites="${DOTPATH}/etc/init/linux/fedora/prerequisites.sh"
+if is_linux && [ -d "${DOTPATH}" ]; then
+    prerequisites="${DOTPATH}/etc/init/linux/$(linux_family)/prerequisites.sh"
     if [ -f "$prerequisites" ]; then
         bash "$prerequisites"
-    else
+    elif is_fedora ; then
         echo "Installing prerequisites..."
         sudo dnf install -y git make
+    elif is_ubuntu ; then
+        echo "Installing prerequisites..."
+        sudo apt-get update
+        sudo apt-get install -y git make
     fi
 fi
 
-if is_fedora && ! command -v make > /dev/null 2>&1; then
+if is_linux && ! command -v make > /dev/null 2>&1; then
     echo "error: make is required but not installed"
     exit 1
 fi

--- a/test/suite/30-runtime.sh
+++ b/test/suite/30-runtime.sh
@@ -60,7 +60,7 @@ for cmd in zsh git make nvim tmux; do
     if have "$cmd"; then
         ok "$cmd が入っている"
     else
-        fail "$cmd が入っている" "Brewfile / dnf の一覧を確認する"
+        fail "$cmd が入っている" "Brewfile / dnf / apt の一覧を確認する"
     fi
 done
 


### PR DESCRIPTION
## 何をしたか

Ubuntu で `install.sh` を流すと `Unsupported Linux distribution. Abort.` で止まっていた。Linux の分岐が `/etc/os-release` の `ID=fedora` しか見ていなかったため。Ubuntu を Fedora と同じ扱いにした。

判定は Debian 系全体を拾う。`ID=debian` と、`ID_LIKE` でしか名乗らない派生 (Linux Mint など) も通る。

## dnf の経路と違うところ

**パッケージ名の欠落** — `apt-get` はコマンドラインの名前を一つでも解決できないと、他が揃っていても何もインストールせずに終わる。しかもリリースによって顔ぶれが違い、古いものには `git-delta` や `yt-dlp` が無い。候補を `apt-cache` に通してから渡し、無いものは warning として名前を出すだけにして、install 全体を道連れにしないようにした。

**gh** — Ubuntu の標準リポジトリには無いので、GitHub が案内している通りに apt リポジトリを追加する。**サードパーティのリポジトリが一つ増える**ので、そこだけ判断してほしい。

**Neovim** — apt のものは設定が要求するより古い (24.04 でも 0.9 系、`nvim-treesitter` の main ブランチは 0.11 以降が必要)。古ければ公式ビルドを `~/.local/nvim` に展開する。`.zshenv` が `~/.local/bin` を PATH の先頭に置くので、そちらが優先される。`fd` / `bat` が `fdfind` / `batcat` から本来の名前を取り戻すのも同じ場所。

## CI

syntax と deploy を Ubuntu コンテナでも回す。対象が 2 つから 3 つになったので、setup のコマンドは matrix 側の 1 行に寄せた。

## 検証

- 変更したスクリプトへの `bash -n` と `shellcheck -x` は pass
- ディストリ判定の `case` は主要な `ID` / `ID_LIKE` の組み合わせで確認済み
- **実機の Ubuntu では未検証** (作業は macOS 上)。CI の Ubuntu ジョブが syntax と deploy を見るが、`install.sh` を頭から流すジョブは今も macOS だけなので、apt の経路そのものは初回の実行が最初の確認になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XveJUg7NaPALhP6VpZcirZ