### PR TITLE
fix: quiet the first run on a fresh Linux machine

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -25,8 +25,18 @@ alias diff="colordiff"
 # alias cat='bat'
 alias gip='curl ifconfig.io/all'
 
-if [ `uname -m` = "arm64" ]; then
-  eval $(/opt/homebrew/bin/brew shellenv)
-else
-  eval $(/usr/local/bin/brew shellenv)
-fi
+# Homebrew。置き場所は環境ごとに違い (Apple Silicon / Intel / Linuxbrew)、
+# Linux では入っていないこともあるので、実際にあるものを使う。
+# アーキテクチャで振り分けると、Linux が Intel Mac のパスを掴んで毎回エラーになる
+for brew_candidate in \
+  /opt/homebrew/bin/brew \
+  /usr/local/bin/brew \
+  /home/linuxbrew/.linuxbrew/bin/brew \
+  "$HOME/.linuxbrew/bin/brew"
+do
+  if [ -x "$brew_candidate" ]; then
+    eval "$("$brew_candidate" shellenv)"
+    break
+  fi
+done
+unset brew_candidate

--- a/etc/init/install.sh
+++ b/etc/init/install.sh
@@ -66,6 +66,37 @@ if [ -z "$CI" ] ; then
     mkdir -p "$HOME/.vim/backup"
 fi
 
+# tree-sitter の CLI。nvim-treesitter の main ブランチはパーサのビルドをこれに任せる
+# ので、無いと :TSUpdate が ENOENT で落ちる。macOS は Brewfile の tree-sitter-cli で
+# 入るが、dnf にも apt にも使えるものが無い (あっても main が要求するより古い) ので、
+# Linux では公式のリリースを ~/.local/bin に置く
+install_tree_sitter_cli() {
+    local asset url
+    case "$(uname -m)" in
+        x86_64) asset="tree-sitter-linux-x64.gz" ;;
+        aarch64 | arm64) asset="tree-sitter-linux-arm64.gz" ;;
+        *)
+            echo "warning: no official tree-sitter build for $(uname -m)"
+            return 1
+            ;;
+    esac
+
+    url="https://github.com/tree-sitter/tree-sitter/releases/latest/download/${asset}"
+    echo "Installing the tree-sitter CLI from ${url}..."
+    mkdir -p "$HOME/.local/bin"
+    if ! curl -fsSL "$url" | gunzip > "$HOME/.local/bin/tree-sitter"; then
+        rm -f "$HOME/.local/bin/tree-sitter"
+        echo "warning: failed to download the tree-sitter CLI"
+        return 1
+    fi
+    chmod +x "$HOME/.local/bin/tree-sitter"
+    hash -r
+}
+
+if [ -z "$CI" ] && is_linux && ! command -v tree-sitter > /dev/null 2>&1 ; then
+    install_tree_sitter_cli || true
+fi
+
 # Neovim: lazy.nvim は .config/nvim/init.lua が自前で bootstrap するので、
 # ここでは初回のプラグイン同期だけ済ませておく
 # (mason の LSP サーバは headless では入らないので、初回の nvim 起動時に導入される)

--- a/etc/init/install.sh
+++ b/etc/init/install.sh
@@ -117,4 +117,20 @@ if [ -z "$CI" ] && command -v tmux > /dev/null 2>&1 ; then
         echo "Installing tmux plugins..."
         "$tpm_path/bin/install_plugins"
     fi
+
+    # continuum は tmux サーバの起動時に復元を試みる。保存が一度も無い新しい
+    # マシンでは resurrect が "Tmux resurrect file not found!" と出してくるので、
+    # 空の保存を置いて黙らせる (次の自動保存が普通に上書きしていく)
+    resurrect_dir="${XDG_DATA_HOME:-$HOME/.local/share}/tmux/resurrect"
+    if [ -d "$HOME/.tmux/resurrect" ]; then
+        # resurrect は旧い置き場が既にあればそちらを使う
+        resurrect_dir="$HOME/.tmux/resurrect"
+    fi
+    if [ ! -e "$resurrect_dir/last" ]; then
+        echo "Seeding an empty tmux-resurrect save..."
+        mkdir -p "$resurrect_dir"
+        resurrect_seed="tmux_resurrect_$(date +%Y%m%dT%H%M%S).txt"
+        : > "$resurrect_dir/$resurrect_seed"
+        ln -sfn "$resurrect_seed" "$resurrect_dir/last"
+    fi
 fi


### PR DESCRIPTION
WSL (Ubuntu) に #74 を入れてみたら、インストール自体は通ったものの起動のたびに 3 つ声が上がったので、その 3 つ。独立した修正なのでコミットも 3 つに分けてある。

## 1. `.zprofile: no such file or directory: /usr/local/bin/brew`

`.zprofile` が `uname -m` で置き場所を決めていて、arm64 でなければ Intel Mac のパスを決め打ちで eval していた。Linux にそのファイルは無いので、ログインシェルを開くたびに出る。

アーキテクチャが場所の代わりをしていたが、それは場所自身に聞けばわかる。候補を順に見て実在するものを使う形にした。Linuxbrew の 2 箇所も候補に入れてある。brew がまったく無い環境では黙って何もしない。

## 2. `Tmux resurrect file not found!`

設定の壊れではなく、`@continuum-restore 'on'` がサーバ起動時に復元を試み、保存が一度も無いので resurrect が言っているだけ（`restore.sh` の `check_saved_session_exists`）。

害は無いが、新しいマシンを開くたびに出迎えてくる。しかも消えるのは continuum の初回保存が落ちてからで、それには tmux サーバが保存間隔のあいだ生きている必要がある。インストール時に空の保存を置いて、初回の復元を no-op にした。次の実保存が普通に上書きしていく。

## 3. `Error during "tree-sitter build" ENOENT ... "tree-sitter"`

#74 の抜け。nvim-treesitter の main ブランチはパーサのビルドを tree-sitter CLI に渡すので、CLI が無いと初回のプラグイン同期がここで落ちる。

macOS は Brewfile の `tree-sitter-cli` で入っていた。dnf にも apt にも main が満足するものが無い（あってもマイナーバージョンがいくつか後ろ）ので、Linux では公式のリリースを `~/.local/bin` に置く。`.zshenv` が PATH の先頭に入れている場所。

どちらのディストリも同じ理由で必要なので、置き場は各ディストリのスクリプトではなくプラグイン同期の手前にした。**Fedora 側の同じ穴もこれで塞がる。**

## 検証

- `bash -n` / `shellcheck -x` / `zsh -n` は pass
- brew の候補を実在しないパスに差し替えて「brew がまったく無い」状態を再現し、無出力・exit 0 を確認。macOS では従来どおり `/opt/homebrew` を拾う
- リリースの資産名は GitHub の API で実物を確認（`tree-sitter-linux-x64.gz` / `-arm64.gz`）。ダウンロードと `gunzip` も実際に通して Linux x86-64 の ELF が出ることまで見た
- **実機の WSL では未検証。** 手元は macOS で、報告された 3 つの症状の再現もできていない（いずれも「Linux で、かつ新品のマシンで」出るもの）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XveJUg7NaPALhP6VpZcirZ