### PR TITLE
feat(bin): PR ごとの worktree を hunk で読むための道具立て

### DIFF
--- a/.zsh/worktree-hooks/80-review
+++ b/.zsh/worktree-hooks/80-review
@@ -1,0 +1,53 @@
+#!/usr/bin/env zsh
+#
+# worktree hook: PR の worktree を作ったら、レビュー用の tmux ウィンドウを開く
+#
+# fprwtree で PR を選ぶ → worktree ができる → hunk + terminal + claude の窓が開く、
+# までを 1 手にする。窓を作るのは bin/pr-review。
+#
+# PR 以外 (fnewtree / fbrwtree など) では何もしない。実装しに行くだけで
+# レビュー窓が要らないときは、下のどちらかで切る。
+#
+#   WTREE_NO_REVIEW=1           一時的に切る
+#   WTREE_HOOKS_SKIP=review     フック機構側で飛ばす
+#
+# あとから開きたくなったら worktree の中で pr-review を叩けばよい。
+#
+
+if [ -n "$WTREE_NO_REVIEW" ]; then
+  return 0
+fi
+
+# PR から作った worktree だけが対象
+if [ "$WT_SOURCE" != "pr" ] || [ -z "$WT_PR_NUMBER" ]; then
+  return 0
+fi
+
+# tmux の外では窓を作れない。pr-review (tmux-workspace) はセッションごと作って
+# attach しようとするので、フックの途中でシェルを奪われないよう先に抜ける
+if [ -z "$TMUX" ]; then
+  return 0
+fi
+
+# スクリプト経由 (bin/wtadd など) では黙って作るだけにする。90-cd と同じ方針
+if ! __wt_interactive; then
+  return 0
+fi
+
+if ! command -v pr-review > /dev/null 2>&1; then
+  print -u2 "⚠️  pr-review が見つかりません (dotfiles の bin が PATH にあるか確認)"
+  return 0
+fi
+
+if [ ! -d "$WT_PATH" ]; then
+  print -u2 "❌ Worktree path not found: $WT_PATH"
+  return 1
+fi
+
+print -u2 "🔍 Opening review window for PR #${WT_PR_NUMBER}..."
+# pr-review は概要を stdout に出すが、stdout は wtadd --print-path のものなので寄せる
+if ! pr-review --pr "$WT_PR_NUMBER" "$WT_PATH" >&2; then
+  print -u2 "⚠️  レビュー窓を開けませんでした (worktree の中で pr-review を叩けば開きます)"
+fi
+
+return 0

--- a/README.md
+++ b/README.md
@@ -61,6 +61,52 @@ LSP サーバは mason 経由で導入されるため、初回起動後 `:Mason`
 
 `.vimrc` は sudo 時など vim しか無い環境向けに、プラグイン非依存の最小設定だけを残しています。
 
+## PR レビュー
+
+PR ごとに worktree を作り、[hunk](https://hunk.dev/) の diff にエージェントの解説を
+付けながら読むための道具立てです。
+
+```bash
+fprwtree                 # PR を fzf で選んで worktree を作る (既存の zsh 関数)
+pr-review                # その worktree をレビュー用ウィンドウで開く
+```
+
+`pr-review` はレビュー専用の tmux ウィンドウを作ります（`tmux-workspace --editor` で
+エディタのペインを hunk に差し替えたもの）。
+
+```
+┌────────────────────┬──────────┐
+│ hunk diff          │ claude   │
+├────────────────────┤          │
+│ terminal           │          │
+└────────────────────┴──────────┘
+```
+
+worktree のパス (`<親>/<リポジトリ>.worktree/pr-<番号>-<ブランチ>`) から PR 番号を拾い、
+マージ先は `gh pr view` で引いて `origin/<base>...HEAD` を開きます。`fprwtree` が
+`wtadd` に渡す `--base` は PR の head なので、そこは当てになりません。
+
+### 注釈は JSON を正とする
+
+hunk の注釈にはライブ (`hunk session comment apply`) とファイル (`--agent-context`) の
+二通りの入り口があり、ライブはセッションを閉じると消えます。そこで置き場を決めておき、
+エージェントにはそこへ書かせます。
+
+```
+${XDG_STATE_HOME:-~/.local/state}/hunk-review/<リポジトリ>/pr-<番号>.json
+```
+
+`pr-review` はこれがあれば `--agent-context` で読み込むので、次に開いたときも解説が出ます
+（worktree を消しても残ります）。開いている最中に反映したいときは `hunk-notes` を使います。
+
+```bash
+pr-review --print-notes                     # 置き場を出す (エージェントに渡す)
+hunk-notes <notes.json> --replace --focus   # JSON を今開いている hunk に流し込む
+```
+
+同じ worktree に対して `pr-review` を二度呼んでも窓は増えず、開いている hunk の中身を
+差し替えます（同一リポジトリに hunk が 2 つあると `--repo` の指定が曖昧になるため）。
+
 ## Test
 
 ```bash

--- a/bin/hunk-notes
+++ b/bin/hunk-notes
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""agent-context 形式の注釈 JSON を、動いている hunk セッションに流し込む。
+
+hunk の注釈には二通りの入り口がある。
+
+  - ライブ: hunk session comment apply。すぐ出るが、セッションを閉じると消える
+  - ファイル: hunk diff --agent-context notes.json。残るが、開き直さないと反映されない
+
+どちらか一方で運用すると「対話で付けた解説が消える」か「解説が出るまで開き直す」
+のどちらかを踏むので、JSON を唯一の正として、そこからライブへ流す形にする。
+エージェントは JSON を書き、これを呼ぶ。次に pr-review で開くときは --agent-context
+で同じ内容が出る。
+
+Usage:
+  hunk-notes <notes.json> [--repo <path>] [--replace] [--focus] [--dry-run]
+
+  --repo <path>   対象の hunk セッション (既定: カレントディレクトリ)
+  --replace       流し込む前に、そのセッションの既存の注釈を消す
+  --focus         最初の注釈に視点を飛ばす
+  --dry-run       流し込まず、組み立てたバッチを出す
+
+JSON の形 (hunk の agent-context と同じ):
+  {"version": 1,
+   "summary": "PR 全体の要約",
+   "files": [{"path": "src/a.ts",
+              "summary": "このファイルの役割",
+              "annotations": [{"newRange": [10, 20],
+                               "summary": "ここが肝",
+                               "rationale": "なぜそうしたか",
+                               "author": "claude"}]}]}
+
+annotations の位置は newRange / oldRange / newLine / oldLine / hunk のいずれか。
+range を渡した場合は、その先頭行に注釈が付く (hunk のライブ注釈は行単位)。
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+
+def find_hunk() -> str:
+    """hunk の実行ファイルを探す。mise 管理下は PATH に載っていないことがある。"""
+    found = shutil.which("hunk")
+    if found:
+        return found
+    if shutil.which("mise"):
+        result = subprocess.run(
+            ["mise", "which", "hunk"], capture_output=True, text=True, check=False
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    sys.exit("hunk-notes: hunk が見つかりません (mise install で入ります)")
+
+
+def target_of(annotation: dict) -> dict:
+    """agent-context の位置指定を、ライブ注釈の位置指定に移す。"""
+    for key in ("newLine", "oldLine", "hunk", "hunkNumber"):
+        if annotation.get(key) is not None:
+            return {key: annotation[key]}
+    for key, line_key in (("newRange", "newLine"), ("oldRange", "oldLine")):
+        value = annotation.get(key)
+        if isinstance(value, (list, tuple)) and value:
+            return {line_key: value[0]}
+    return {}
+
+
+def to_batch(context: dict) -> list:
+    comments = []
+    for entry in context.get("files", []):
+        path = entry.get("path")
+        if not path:
+            continue
+        for annotation in entry.get("annotations", []):
+            summary = annotation.get("summary")
+            target = target_of(annotation)
+            if not summary or not target:
+                sys.exit(
+                    f"hunk-notes: {path} の注釈に summary か位置がありません: {annotation!r}"
+                )
+            comment = {"filePath": path, "summary": summary, **target}
+            for key in ("rationale", "author", "markup"):
+                if annotation.get(key):
+                    comment[key] = annotation[key]
+            comments.append(comment)
+    return comments
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("notes", nargs="?")
+    parser.add_argument("--repo", default=".")
+    parser.add_argument("--replace", action="store_true")
+    parser.add_argument("--focus", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("-h", "--help", action="store_true")
+    args = parser.parse_args()
+
+    if args.help or not args.notes:
+        print(__doc__.strip())
+        sys.exit(0 if args.help else 2)
+
+    if not os.path.isfile(args.notes):
+        sys.exit(f"hunk-notes: no such file: {args.notes}")
+    with open(args.notes, encoding="utf-8") as handle:
+        try:
+            context = json.load(handle)
+        except json.JSONDecodeError as error:
+            sys.exit(f"hunk-notes: {args.notes} が JSON として読めません: {error}")
+
+    comments = to_batch(context)
+    if not comments:
+        sys.exit(f"hunk-notes: {args.notes} に注釈がありません")
+
+    payload = json.dumps({"comments": comments}, ensure_ascii=False)
+    if args.dry_run:
+        print(payload)
+        return
+
+    hunk = find_hunk()
+    repo = os.path.abspath(args.repo)
+
+    if args.replace:
+        subprocess.run(
+            [hunk, "session", "comment", "clear", "--repo", repo, "--yes"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+        )
+
+    command = [hunk, "session", "comment", "apply", "--repo", repo, "--stdin"]
+    if args.focus:
+        command.append("--focus")
+    result = subprocess.run(command, input=payload, text=True, check=False)
+    if result.returncode != 0:
+        sys.exit(
+            "hunk-notes: 流し込みに失敗しました。"
+            "hunk がその worktree を開いているか (hunk session list) を確認してください"
+        )
+    print(f"{len(comments)} 件の注釈を反映しました ({args.notes})")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/pr-review
+++ b/bin/pr-review
@@ -1,0 +1,226 @@
+#!/usr/bin/env sh
+# PR の worktree を hunk で開く。レビュー専用の tmux ウィンドウを作る。
+#
+#   ┌────────────────────┬──────────┐
+#   │ hunk diff          │ claude   │
+#   ├────────────────────┤          │
+#   │ terminal           │          │
+#   └────────────────────┴──────────┘
+#
+#   pr-review                   PR の worktree を選ぶ (cwd がそれならそのまま)
+#   pr-review <path>            worktree を指定する
+#   pr-review --pr 123          PR 番号を明示する (パスから拾えないとき)
+#   pr-review --range a...b     diff の範囲を明示する (gh を呼ばない)
+#   pr-review --print-notes     注釈 JSON の置き場だけ出す
+#   pr-review --dry-run         開かずに、実行するコマンドを出す
+#
+# worktree を作るのは fprwtree で、こちらは「開く」だけ。
+# hunk が既にその worktree を開いていれば、窓を増やさず中身を差し替える。
+#
+# 注釈 (agent-context 形式の JSON) の置き場:
+#   ${XDG_STATE_HOME:-~/.local/state}/hunk-review/<リポジトリ>/pr-<番号>.json
+# あれば --agent-context で読み込む。worktree を消しても残るので、
+# エージェントに書かせた解説は次に開いたときもそのまま出る。
+
+set -eu
+
+pr=""
+range=""
+notes=""
+name=""
+print_notes=0
+dry_run=0
+
+die() {
+    echo "pr-review: $1" >&2
+    exit 1
+}
+
+while [ $# -gt 0 ]; do
+    case $1 in
+        --pr)
+            pr=${2:?"--pr needs a number"}
+            shift 2
+            ;;
+        --range)
+            range=${2:?"--range needs a git range"}
+            shift 2
+            ;;
+        --notes)
+            notes=${2:?"--notes needs a path"}
+            shift 2
+            ;;
+        -n)
+            name=${2:?"-n needs a window name"}
+            shift 2
+            ;;
+        --print-notes)
+            print_notes=1
+            shift
+            ;;
+        --dry-run)
+            dry_run=1
+            shift
+            ;;
+        -h | --help)
+            sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        -*)
+            die "unknown option: $1"
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+# --- worktree を決める -------------------------------------------------------
+
+# <親>/<リポジトリ>.worktree/pr-123-feat/x → pr-123-feat
+# ブランチ名に / が入ると worktree のパスも階層になるので、basename では拾えない
+worktree_label() {
+    case $1 in
+        *.worktree/*)
+            rest=${1#*.worktree/}
+            printf '%s' "${rest%%/*}"
+            ;;
+        *)
+            basename "$1"
+            ;;
+    esac
+}
+
+is_pr_worktree() {
+    case $(worktree_label "$1") in
+        pr-[0-9]*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# git worktree list からこのリポジトリの PR worktree を並べる
+list_pr_worktrees() {
+    git worktree list --porcelain 2> /dev/null |
+        while IFS= read -r line; do
+            case $line in
+                "worktree "*) path=${line#worktree } ;;
+                *) continue ;;
+            esac
+            if is_pr_worktree "$path"; then
+                echo "$path"
+            fi
+        done
+}
+
+dir=${1:-}
+if [ -z "$dir" ]; then
+    top=$(git rev-parse --show-toplevel 2> /dev/null) ||
+        die "git リポジトリの中で実行するか、worktree のパスを渡してください"
+    if is_pr_worktree "$top"; then
+        dir=$top
+    else
+        candidates=$(list_pr_worktrees)
+        count=$(printf '%s' "$candidates" | grep -c . || true)
+        if [ "$count" -eq 0 ]; then
+            die "PR の worktree が見つかりません (先に fprwtree で作ってください)"
+        elif [ "$count" -eq 1 ]; then
+            dir=$candidates
+        elif command -v fzf > /dev/null 2>&1; then
+            dir=$(printf '%s\n' "$candidates" |
+                fzf --prompt="PR worktree > " --reverse --border) || exit 0
+        else
+            echo "pr-review: どの worktree か決められません:" >&2
+            printf '%s\n' "$candidates" >&2
+            exit 1
+        fi
+    fi
+fi
+
+[ -d "$dir" ] || die "no such directory: $dir"
+dir=$(cd "$dir" && pwd -P)
+
+# --- PR 番号とリポジトリ名 ---------------------------------------------------
+
+if [ -z "$pr" ]; then
+    label=$(worktree_label "$dir")
+    case $label in
+        pr-[0-9]*) pr=$(printf '%s' "$label" | sed 's/^pr-\([0-9][0-9]*\).*/\1/') ;;
+        *) die "PR 番号が分かりません (--pr で渡してください): $label" ;;
+    esac
+fi
+
+# worktree からでも本体の .git を辿ってリポジトリ名を取る
+common=$(git -C "$dir" rev-parse --git-common-dir)
+case $common in
+    /*) ;;
+    *) common=$dir/$common ;;
+esac
+repo=$(basename "$(cd "$common/.." && pwd -P)")
+
+if [ -z "$notes" ]; then
+    notes="${XDG_STATE_HOME:-$HOME/.local/state}/hunk-review/$repo/pr-$pr.json"
+fi
+
+if [ "$print_notes" -eq 1 ]; then
+    mkdir -p "$(dirname "$notes")"
+    echo "$notes"
+    exit 0
+fi
+
+# --- diff の範囲 -------------------------------------------------------------
+
+# fprwtree が wtadd に渡す --base は PR の head なので、マージ先はここで引く
+if [ -z "$range" ]; then
+    command -v gh > /dev/null 2>&1 ||
+        die "gh が無いので base ブランチを引けません (--range で渡してください)"
+    base=$(cd "$dir" && gh pr view "$pr" --json baseRefName -q .baseRefName 2> /dev/null) ||
+        die "PR #$pr の base ブランチを引けませんでした (--range で渡してください)"
+    [ -n "$base" ] || die "PR #$pr の base ブランチが空でした (--range で渡してください)"
+    if ! git -C "$dir" rev-parse --verify --quiet "origin/$base" > /dev/null; then
+        echo "Fetching origin/$base..."
+        git -C "$dir" fetch origin "$base"
+    fi
+    range="origin/$base...HEAD"
+fi
+
+# --- hunk ------------------------------------------------------------------
+
+hunk_bin=$(command -v hunk 2> /dev/null || true)
+if [ -z "$hunk_bin" ] && command -v mise > /dev/null 2>&1; then
+    hunk_bin=$(mise which hunk 2> /dev/null || true)
+fi
+[ -n "$hunk_bin" ] || die "hunk が見つかりません (mise install で入ります)"
+
+hunk_cmd="'$hunk_bin' diff '$range' --agent-notes"
+if [ -f "$notes" ]; then
+    hunk_cmd="$hunk_cmd --agent-context '$notes'"
+fi
+
+if [ "$dry_run" -eq 1 ]; then
+    echo "worktree: $dir"
+    echo "notes:    $notes$([ -f "$notes" ] || echo ' (まだ無い)')"
+    echo "command:  $hunk_cmd"
+    exit 0
+fi
+
+# 同じ repo に hunk が 2 つ生きていると session の --repo 指定が曖昧になるので、
+# 既に開いている窓があれば増やさずに中身を差し替える
+if "$hunk_bin" session get --repo "$dir" > /dev/null 2>&1; then
+    "$hunk_bin" session reload --repo "$dir" -- diff "$range" > /dev/null
+    echo "既に開いている hunk を PR #$pr に差し替えました"
+else
+    workspace=$(dirname "$0")/tmux-workspace
+    [ -x "$workspace" ] || workspace=tmux-workspace
+    "$workspace" --editor "$hunk_cmd" -n "${name:-pr-$pr}" "$dir"
+fi
+
+cat <<EOF
+PR #$pr  ($repo)
+  worktree: $dir
+  range:    $range
+  notes:    $notes$([ -f "$notes" ] || echo " (まだ無い)")
+
+エージェントに解説させるときは、claude のペインでこう頼む:
+  hunk の skill を読んで、この PR を解説しながら注釈を付けて。
+  注釈は $notes に agent-context 形式で書いて、hunk-notes --replace で反映して。
+EOF

--- a/bin/tmux-workspace
+++ b/bin/tmux-workspace
@@ -9,13 +9,15 @@
 #   │ terminal     │          │
 #   └──────────────┴──────────┘
 #
-#   tmux-workspace                 カレントディレクトリで開く
-#   tmux-workspace ~/src/dc/foo    指定したディレクトリで開く
-#   tmux-workspace -n api ~/src/x  ウィンドウ名を指定する
+#   tmux-workspace                    カレントディレクトリで開く
+#   tmux-workspace ~/src/dc/foo       指定したディレクトリで開く
+#   tmux-workspace -n api ~/src/x     ウィンドウ名を指定する
+#   tmux-workspace --editor lazygit   エディタのペインを別のものにする
+#   tmux-workspace --agent zsh        エージェントのペインを別のものにする
 #
 # 呼ぶたびに新しいウィンドウを作る。同じディレクトリでも並行して作業できる。
 #
-# 中で使うコマンドは tmux のオプションで変えられる:
+# 中で使うコマンドは tmux のオプションでも変えられる (--editor / --agent が優先):
 #   set -g @workspace-editor "nvim ."
 #   set -g @workspace-agent  "claude --continue"
 #   set -g @workspace-agent-percent 40
@@ -23,14 +25,24 @@
 set -eu
 
 name=""
+editor_override=""
+agent_override=""
 while [ $# -gt 0 ]; do
     case $1 in
         -n)
             name=${2:?"-n needs a window name"}
             shift 2
             ;;
+        --editor)
+            editor_override=${2:?"--editor needs a command"}
+            shift 2
+            ;;
+        --agent)
+            agent_override=${2:?"--agent needs a command"}
+            shift 2
+            ;;
         -h | --help)
-            sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)
@@ -51,8 +63,8 @@ option() {
     if [ -n "$value" ]; then printf '%s' "$value"; else printf '%s' "$2"; fi
 }
 
-editor=$(option @workspace-editor "nvim")
-agent=$(option @workspace-agent "claude")
+editor=${editor_override:-$(option @workspace-editor "nvim")}
+agent=${agent_override:-$(option @workspace-agent "claude")}
 agent_percent=$(option @workspace-agent-percent "30")
 terminal_percent=$(option @workspace-terminal-percent "20")
 

--- a/test/suite/30-runtime.sh
+++ b/test/suite/30-runtime.sh
@@ -296,6 +296,52 @@ else
     skip "hunk-notes のスモークテスト" "python3 が無い"
 fi
 
+# worktree フック (80-review)。source されるものなので、pr-review と
+# __wt_interactive を差し替えて分岐だけを見る。窓は開かない
+if have zsh; then
+    review_hook="$DOTPATH/.zsh/worktree-hooks/80-review"
+    review_hook_stub="
+        __wt_interactive() { return 0 }
+        pr-review() { print CALLED }
+        source '$review_hook'
+    "
+
+    output=$(WT_SOURCE=pr WT_PR_NUMBER=77 WT_PATH="$DOTPATH" TMUX=fake \
+        zsh -c "$review_hook_stub" 2>&1)
+    if printf '%s' "$output" | grep -q CALLED; then
+        ok "80-review が PR の worktree で pr-review を呼ぶ"
+    else
+        fail "80-review が PR の worktree で pr-review を呼ぶ" "$output"
+    fi
+
+    # stdout は wtadd --print-path のものなので、フックは汚してはいけない
+    output=$(WT_SOURCE=pr WT_PR_NUMBER=77 WT_PATH="$DOTPATH" TMUX=fake \
+        zsh -c "$review_hook_stub" 2> /dev/null)
+    if [ -z "$output" ]; then
+        ok "80-review が stdout を汚さない"
+    else
+        fail "80-review が stdout を汚さない" "$output"
+    fi
+
+    output=$(WT_SOURCE=branch WT_PR_NUMBER= WT_PATH="$DOTPATH" TMUX=fake \
+        zsh -c "$review_hook_stub" 2>&1)
+    if printf '%s' "$output" | grep -q CALLED; then
+        fail "80-review が PR 以外では何もしない" "$output"
+    else
+        ok "80-review が PR 以外では何もしない"
+    fi
+
+    output=$(env -u TMUX WT_SOURCE=pr WT_PR_NUMBER=77 WT_PATH="$DOTPATH" \
+        zsh -c "$review_hook_stub" 2>&1)
+    if printf '%s' "$output" | grep -q CALLED; then
+        fail "80-review が tmux の外では何もしない" "$output"
+    else
+        ok "80-review が tmux の外では何もしない"
+    fi
+else
+    skip "80-review フックの分岐" "zsh が無い"
+fi
+
 if have tmux; then
     check "tmux-workspace --help が動く" "$DOTPATH/bin/tmux-workspace" --help
 

--- a/test/suite/30-runtime.sh
+++ b/test/suite/30-runtime.sh
@@ -323,7 +323,7 @@ if have zsh; then
         fail "80-review が stdout を汚さない" "$output"
     fi
 
-    output=$(WT_SOURCE=branch WT_PR_NUMBER= WT_PATH="$DOTPATH" TMUX=fake \
+    output=$(WT_SOURCE=branch WT_PR_NUMBER='' WT_PATH="$DOTPATH" TMUX=fake \
         zsh -c "$review_hook_stub" 2>&1)
     if printf '%s' "$output" | grep -q CALLED; then
         fail "80-review が PR 以外では何もしない" "$output"

--- a/test/suite/30-runtime.sh
+++ b/test/suite/30-runtime.sh
@@ -250,8 +250,58 @@ fi
 
 # --- bin のスモークテスト ---------------------------------------------------
 
+check "pr-review --help が動く" "$DOTPATH/bin/pr-review" --help
+
+# PR の worktree だと分からない場所を渡したら、黙って開かずエラーにする
+if output=$("$DOTPATH/bin/pr-review" --dry-run "$DOTPATH" 2>&1); then
+    fail "pr-review が PR 以外の場所で失敗する" "エラーにならなかった: $output"
+else
+    ok "pr-review が PR 以外の場所で失敗する"
+fi
+
+if have python3; then
+    check "hunk-notes --help が動く" "$DOTPATH/bin/hunk-notes" --help
+
+    # agent-context の注釈が、ライブ注釈の形 (行指定) に移ること。
+    # ここがずれると注釈が別の行に付く / 黙って落ちる
+    notes_json=$(mktemp "${TMPDIR:-/tmp}/dotfiles-test-notes.XXXXXX") || notes_json=""
+    if [ -n "$notes_json" ]; then
+        cat > "$notes_json" <<'JSON'
+{"version": 1,
+ "files": [{"path": "a.txt",
+            "annotations": [{"newRange": [12, 20], "summary": "s", "rationale": "r"}]}]}
+JSON
+        output=$("$DOTPATH/bin/hunk-notes" "$notes_json" --dry-run 2>&1)
+        if printf '%s' "$output" | grep -q '"newLine": 12' &&
+            printf '%s' "$output" | grep -q '"filePath": "a.txt"'; then
+            ok "hunk-notes が newRange を行指定に移す"
+        else
+            fail "hunk-notes が newRange を行指定に移す" "$output"
+        fi
+
+        # 位置の無い注釈は黙って捨てずにエラーにする
+        cat > "$notes_json" <<'JSON'
+{"files": [{"path": "a.txt", "annotations": [{"summary": "位置が無い"}]}]}
+JSON
+        if output=$("$DOTPATH/bin/hunk-notes" "$notes_json" --dry-run 2>&1); then
+            fail "hunk-notes が位置の無い注釈で失敗する" "エラーにならなかった: $output"
+        else
+            ok "hunk-notes が位置の無い注釈で失敗する"
+        fi
+        rm -f "$notes_json"
+    else
+        skip "hunk-notes の変換" "一時ファイルを作れない"
+    fi
+else
+    skip "hunk-notes のスモークテスト" "python3 が無い"
+fi
+
 if have tmux; then
     check "tmux-workspace --help が動く" "$DOTPATH/bin/tmux-workspace" --help
+
+    # --editor / --agent が渡せること (pr-review が hunk を差し込むのに使う)
+    check "tmux-workspace が --editor を受ける" \
+        sh -c "'$DOTPATH/bin/tmux-workspace' --help | grep -q -- --editor"
 else
     skip "tmux-workspace --help" "tmux が無い"
 fi


### PR DESCRIPTION
## 何をしたか

PR ごとに worktree を作って、[hunk](https://hunk.dev/) の diff にエージェントの解説を付けながら読むための道具立てです。`fprwtree` で PR を選ぶと、worktree の作成からレビュー窓が開くまでが 1 手で済みます。

```
$ fprwtree
🔍 Fetching pull requests...          # fzf で PR を選ぶ
✅ Worktree created: ~/src/dc/x.worktree/pr-123-feat/y
🔍 Opening review window for PR #123...

┌────────────────────┬──────────┐
│ hunk diff          │ claude   │   ← origin/<base>...HEAD
├────────────────────┤          │
│ terminal           │          │
└────────────────────┴──────────┘
```

| 追加したもの | 役割 |
| --- | --- |
| `bin/pr-review` | worktree をレビュー用ウィンドウで開く |
| `bin/hunk-notes` | agent-context JSON を、動いている hunk に流し込む |
| `.zsh/worktree-hooks/80-review` | PR の worktree を作ったら `pr-review` を呼ぶ |
| `bin/tmux-workspace` | `--editor` / `--agent` を追加 |

## なぜこうしたか

**注釈は JSON を正とする。** hunk の注釈にはライブ (`comment apply`) とファイル (`--agent-context`) の 2 つの入り口があり、ライブはセッションを閉じると消えます。片方だけで運用すると「対話で付けた解説が消える」か「解説が出るまで開き直す」のどちらかを踏むので、置き場を `${XDG_STATE_HOME:-~/.local/state}/hunk-review/<リポジトリ>/pr-<番号>.json` に決めて、エージェントにはそこへ書かせ、`hunk-notes` でライブへ流します。worktree を消しても残ります。

**マージ先は `gh pr view` で引く。** `fprwtree` が `wtadd` に渡す `--base` は PR の head なので、フックに来る `WT_BASE` は diff の起点になりません。

**PR 番号は basename では取れない。** ブランチ名に `/` が入ると worktree のパスも階層になる (`pr-123-feat/y` → `pr-123-feat/` + `y/`) ので、`<リポジトリ>.worktree/` の次の要素から取ります。

**同じ worktree に二度呼んでも窓を増やさず reload する。** 同一リポジトリに hunk が 2 つ生きていると `hunk session --repo` の指定が曖昧になり、見えていない方に注釈が入ります (実際に踏みました)。

**フックは stdout を汚さない。** `stdout` は `wtadd --print-path` のものなので、ログも `pr-review` の出力も stderr に寄せています。PR 以外の経路では何もせず、`WTREE_NO_REVIEW=1` / `WTREE_HOOKS_SKIP=review` で切れます。

## 確認したこと

手元の macOS で、`fprwtree` と同じ命名の worktree (`pr-77-feat/install-hunk`) を作って一通り流しました。

- `pr-review --dry-run`: PR 番号 / リポジトリ名 / 注釈の置き場 / `gh` から引いた range
- 実起動: hunk + terminal + claude の 3 ペインが開き、`--agent-context` の注釈が `╭─ claude note - etc/init/install.sh R160–R175 ─╮` として描画される
- `hunk-notes --replace --focus`: 5 件のライブ反映
- 二度目の `pr-review`: 窓を増やさず reload
- `80-review` の分岐: PR で呼ぶ / stdout を汚さない / PR 以外は何もしない / tmux の外では何もしない (stub に差し替えて確認、テストにも追加)

`make test-runtime` などのスイート自体と shellcheck は未実行です (CI に任せています)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVhrWf29FaYtZ6kbn8LhDY