### PR TITLE
feat(nvim): tone down markview decoration to glow level

### DIFF
--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -143,11 +143,110 @@ return {
     opts = {},
   },
 
-  -- Markdown をバッファ内で整形して表示する
+  -- Markdown をバッファ内で整形して表示する。
+  --
+  -- 既定は見出し 1〜6 をそれぞれ別色の「背景ブロック」で描く
+  -- (MarkviewHeading{N} -> MarkviewPalette{N} = Normal の bg に見出し色を 25% 混ぜた帯)。
+  -- solarized dark だと帯が濁って本文より読みにくいので、glow (charmbracelet) の
+  -- dark スタイル相当まで装飾量を落とす:
+  --   h1 だけ帯、h2〜h5 は `##` を残した青の太字、h6 は緑・太字なし。
   {
     "OXY2DEV/markview.nvim",
     ft = { "markdown", "quarto", "rmd", "codecompanion" },
     dependencies = { "nvim-tree/nvim-web-devicons" },
-    opts = {},
+    config = function()
+      -- markview の MarkviewHeading* は ColorScheme のたびに MarkviewPalette* へ
+      -- 貼り替えられ、opts.highlight_groups は現行 commit では配線されていないので、
+      -- 衝突しない独自名のグループを自前で張る (`:colorscheme` で消えるため再作成も自分で)。
+      local function heading_hl()
+        local set = vim.api.nvim_set_hl
+        -- glow の dark スタイルを solarized のパレットに置き換えたもの
+        set(0, "MdHeading1", { fg = "#fdf6e3", bg = "#6c71c4", bold = true }) -- base3 on violet
+        set(0, "MdHeading2", { fg = "#268bd2", bold = true }) -- blue
+        set(0, "MdHeading3", { fg = "#268bd2", bold = true })
+        set(0, "MdHeading4", { fg = "#268bd2", bold = true })
+        set(0, "MdHeading5", { fg = "#268bd2", bold = true })
+        set(0, "MdHeading6", { fg = "#859900" }) -- green (glow に合わせて太字なし)
+        -- setext (`===` 下線) 見出し用。simple スタイルは line_hl_group で行全体を塗るので、
+        -- h1 の帯をそのまま使うと画面端まで violet になる。色だけ借りる。
+        set(0, "MdHeadingSetext1", { fg = "#6c71c4", bold = true })
+      end
+
+      heading_hl()
+      vim.api.nvim_create_autocmd("ColorScheme", {
+        group = vim.api.nvim_create_augroup("MarkviewHeadingHl", { clear = true }),
+        callback = heading_hl,
+      })
+
+      require("markview").setup({
+        markdown = {
+          headings = {
+            shift_width = 0, -- 見出しをレベル分インデントしない
+
+            -- h1 は `#` を隠して前後に空白を足した帯にする (glow の h1 相当)
+            heading_1 = {
+              style = "label",
+              sign = false,
+              padding_left = " ",
+              padding_right = " ",
+              icon = "",
+              hl = "MdHeading1",
+            },
+
+            -- h2 以降は記号を残したまま行に色を乗せるだけ
+            heading_2 = { style = "simple", sign = false, hl = "MdHeading2" },
+            heading_3 = { style = "simple", hl = "MdHeading3" },
+            heading_4 = { style = "simple", hl = "MdHeading4" },
+            heading_5 = { style = "simple", hl = "MdHeading5" },
+            heading_6 = { style = "simple", hl = "MdHeading6" },
+
+            setext_1 = { style = "simple", sign = false, hl = "MdHeadingSetext1" },
+            setext_2 = { style = "simple", sign = false, hl = "MdHeading2" },
+          },
+
+          -- 箇条書きの記号を glow と同じ中黒に揃える (既定は ● / ◈ / ◇ で階層ごとに別記号)
+          list_items = {
+            marker_minus = { text = "•" },
+            marker_plus = { text = "•" },
+            marker_star = { text = "•" },
+          },
+
+          -- 引用は太いブロックではなく細い縦線
+          block_quotes = {
+            default = { border = "│" },
+          },
+
+          -- `---` は既定だと虹色グラデーション + 中央にアイコンなので、ただの罫線にする。
+          -- 既定の parts は 3 要素で、tbl_deep_extend が index ごとに混ぜてしまうため、
+          -- 2/3 番目も明示的に無効化する。
+          horizontal_rules = {
+            parts = {
+              {
+                type = "repeating",
+                direction = "left",
+                repeat_amount = function()
+                  return vim.o.columns
+                end,
+                text = "─",
+                hl = "Comment",
+              },
+              { type = "text", text = "", hl = "Comment" },
+              {
+                type = "repeating",
+                direction = "right",
+                repeat_amount = function()
+                  return 0
+                end,
+                text = "─",
+                hl = "Comment",
+              },
+            },
+          },
+
+          -- テーブルは 1 本線の罫線 (既定は太さの違う複合罫線)
+          tables = require("markview.presets").tables.single,
+        },
+      })
+    end,
   },
 }


### PR DESCRIPTION
## 背景

nvim の markview.nvim を `opts = {}` の全デフォルトで使っていたが、見出しが読みにくかった。

原因は markview の既定のパレット生成。`MarkviewHeading{N}` は `MarkviewPalette{N}` に link されていて、`create_pallete` が **Normal の bg に見出し色を alpha 0.25 で混ぜた背景**を作る。solarized dark (base03 `#002b36`) に混ぜると 6 段とも濁った帯になり、本文より読みにくい。加えて既定は `style = "icon"` で `#` をアイコンに置換し、sign 列にも記号を出すので装飾量が多い。

terminal renderer として使っている [glow](https://github.com/charmbracelet/glow) (glamour の dark スタイル) くらいの装飾量が読みやすいので、そこに寄せる。

## 変更点

| 要素 | Before | After |
|---|---|---|
| h1 | アイコン + 濁った帯 + sign | label スタイルの帯のみ (base3 on violet) |
| h2〜h5 | レベルごとに別色のアイコン + 帯 | `##` を残した blue の太字 (`style = "simple"`) |
| h6 | 同上 | green・太字なし |
| リスト記号 | `●` / `◈` / `◇` | `•` に統一 |
| 引用 border | `▋` | `│` |
| `---` | 虹色グラデーション + 中央アイコン | 素の `─` 全幅 |
| テーブル | 太さの違う複合罫線 | 1 本線 (`presets.tables.single`) |

コードブロックは glow と違って言語アイコンの sign が出るが、実用上有用なので既定のまま残している。

## 実装メモ

ハマったところを 3 つ。

- **`opts.highlight_groups` は効かない。** spec に宣言はあるが、`highlights.setup()` は `autocmds.lua` から常に引数なしで呼ばれていて配線されていない。なので独自名の hl group (`MdHeading1` 〜 `MdHeading6`) を自前で張る。`utils.set_hl` が `Markview`+name → `Markview_`+name → 素の name の順で解決するので、独自名をそのまま `hl` に渡せる。`:colorscheme` で消える分は ColorScheme autocmd で再作成する。
- **setext 見出し (`===` 下線) は `simple` スタイルしか無い。** `simple` は `line_hl_group` で行全体を塗るため、h1 の帯をそのまま使うと画面端まで violet になる。色だけ借りる別グループにした。
- **`horizontal_rules` に preset をそのまま渡すと壊れる。** 既定の `parts` が 3 要素で、`vim.tbl_deep_extend` が index ごとに混ぜてしまう。1 要素の preset を渡すと 2/3 番目が既定のまま残るので、明示的に無効化した。

## 検証

- `loadfile` で構文チェック OK
- headless の nvim でサンプル Markdown を開いてエラーなし
- extmark をダンプして、h1 = label + `MdHeading1` / h2,h3,h6 = `line_hl_group` / `•` / `│` / 素の `─` / `┌─┬─┐` が出ることを確認
- 実際の端末での見た目も確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpLz4htU6pXdFZ6wJTWivF
